### PR TITLE
18 remind endpoint survey

### DIFF
--- a/lib/components/RequiredActionBadge.dart
+++ b/lib/components/RequiredActionBadge.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+
+class RequiredActionBadge extends StatefulWidget {
+
+  final String text;
+  final double badgeSize = 30.0;
+  final double textSize = 16.0;
+  final bool animate;
+
+  RequiredActionBadge(this.text, {this.animate: false});
+
+  @override
+  State<StatefulWidget> createState() => _RequiredActionBadgeState();
+
+}
+
+class _RequiredActionBadgeState extends State<RequiredActionBadge> with SingleTickerProviderStateMixin {
+
+  AnimationController _controller;
+  Animation<double> _containerAnimation;
+  Animation<double> _textAnimation;
+  Curve _curve = Curves.elasticOut;
+
+  @override
+  void initState() {
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 1000),
+      vsync: this,
+    );
+
+    _containerAnimation = Tween<double>(
+      begin: 0.0,
+      end: widget.badgeSize,
+    ).chain(
+        CurveTween(curve: _curve)
+    ).animate(_controller);
+
+    _textAnimation = Tween<double>(
+      begin: 0.0,
+      end: widget.textSize,
+    ).chain(
+        CurveTween(curve: _curve)
+    ).animate(_controller);
+
+    _controller.addListener(() {
+      setState(() {});
+    });
+
+    _animateIfDemanded();
+    super.initState();
+  }
+
+  @override
+  void didUpdateWidget(RequiredActionBadge oldWidget) {
+    _animateIfDemanded();
+    super.didUpdateWidget(oldWidget);
+  }
+
+  void _animateIfDemanded() {
+    if (widget.animate) {
+      _controller.reset();
+      _controller.forward();
+    } else {
+      // initialize animation to its end state
+      _controller.value = _controller.upperBound;
+    }
+  }
+
+  dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedOverflowBox(
+      size: Size(widget.badgeSize, widget.badgeSize),
+      child:
+      Container(
+        width: _containerAnimation.value,
+        height: _containerAnimation.value,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: Colors.black,
+        ),
+        child: Center(
+          child: Text(
+            widget.text,
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: _textAnimation.value,
+              fontWeight: FontWeight.normal,
+              fontFamily: 'Roboto',
+              decoration: TextDecoration.none,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+}

--- a/lib/components/RequiredActionContainer.dart
+++ b/lib/components/RequiredActionContainer.dart
@@ -59,13 +59,18 @@ class _RequiredActionContainerState extends State<RequiredActionContainer> with 
       _controller.value = _controller.upperBound;
     } else if (widget.animateDirection == AnimateDirection.FORWARD) {
       _controller.reset();
-      _controller.forward();
+      _controller.forward().then((_) {
+        if (widget.onAnimated != null) {
+          widget.onAnimated();
+        }
+      });
     } else if (widget.animateDirection == AnimateDirection.BACKWARD) {
       _controller.value = _controller.upperBound;
-      _controller.animateBack(0.0, duration: Duration(milliseconds: 1000), curve: Curves.ease);
-    }
-    if (widget.onAnimated != null) {
-      widget.onAnimated();
+      _controller.animateBack(0.0, duration: Duration(milliseconds: 1000), curve: Curves.ease).then((_) {
+        if (widget.onAnimated != null) {
+          widget.onAnimated();
+        }
+      });
     }
   }
 

--- a/lib/components/RequiredActionContainer.dart
+++ b/lib/components/RequiredActionContainer.dart
@@ -156,61 +156,64 @@ class _RequiredActionContainerState extends State<RequiredActionContainer> with 
     final double badgeSize = 30.0;
     return SizeTransition(
       sizeFactor: _containerAnimation,
-      child: Card(
-        margin: const EdgeInsets.symmetric(horizontal: 15.0, vertical: 5.0),
-        elevation: 5.0,
-        clipBehavior: Clip.antiAlias,
-        child: Container(
-          color: NOTIFICATION_NORMAL,
-          padding: const EdgeInsets.symmetric(horizontal: 15.0),
-          child: Column(
-            children: [
-              SizedBox(height: 20.0),
-              Container(
-                width: double.infinity,
-                child: Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      Hero(
-                        tag: "RequiredAction_${widget.patient.artNumber}_${widget.actionNumber}",
-                        child: Container(
-                          width: badgeSize,
-                          height: badgeSize,
-                          decoration: BoxDecoration(
-                            shape: BoxShape.circle,
-                            color: Colors.black,
-                          ),
-                          child: Center(
-                            child: Text(
-                              '${widget.actionNumber+1}',
-                              style: TextStyle(
-                                color: Colors.white,
-                                fontSize: 16.0,
-                                fontWeight: FontWeight.normal,
-                                fontFamily: 'Roboto',
-                                decoration: TextDecoration.none,
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 8.0),
+        child: Card(
+          margin: const EdgeInsets.symmetric(horizontal: 15.0),
+          elevation: 5.0,
+          clipBehavior: Clip.antiAlias,
+          child: Container(
+            color: NOTIFICATION_NORMAL,
+            padding: const EdgeInsets.symmetric(horizontal: 15.0),
+            child: Column(
+              children: [
+                SizedBox(height: 20.0),
+                Container(
+                  width: double.infinity,
+                  child: Row(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Hero(
+                          tag: "RequiredAction_${widget.patient.artNumber}_${widget.actionNumber}",
+                          child: Container(
+                            width: badgeSize,
+                            height: badgeSize,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: Colors.black,
+                            ),
+                            child: Center(
+                              child: Text(
+                                '${widget.actionNumber+1}',
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 16.0,
+                                  fontWeight: FontWeight.normal,
+                                  fontFamily: 'Roboto',
+                                  decoration: TextDecoration.none,
+                                ),
                               ),
                             ),
                           ),
                         ),
-                      ),
-                      SizedBox(width: 10.0),
-                      Expanded(
-                        child: Text(
-                          actionText,
-                          textAlign: TextAlign.left,
-                          style: TextStyle(
-                            color: NOTIFICATION_MESSAGE_TEXT,
-                            height: 1.2,
+                        SizedBox(width: 10.0),
+                        Expanded(
+                          child: Text(
+                            actionText,
+                            textAlign: TextAlign.left,
+                            style: TextStyle(
+                              color: NOTIFICATION_MESSAGE_TEXT,
+                              height: 1.2,
+                            ),
                           ),
                         ),
-                      ),
-                    ]),
-              ),
-              actionButton ?? SizedBox(height: 15.0),
-              SizedBox(height: 5.0),
-            ],
+                      ]),
+                ),
+                actionButton ?? SizedBox(height: 15.0),
+                SizedBox(height: 5.0),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/components/RequiredActionContainer.dart
+++ b/lib/components/RequiredActionContainer.dart
@@ -6,14 +6,16 @@ import 'package:pebrapp/state/PatientBloc.dart';
 import 'package:pebrapp/utils/AppColors.dart';
 import 'package:pebrapp/utils/VisibleImpactUtils.dart';
 
+enum AnimateDirection { FORWARD, BACKWARD }
+
 class RequiredActionContainer extends StatefulWidget {
 
   final RequiredAction action;
   final int actionNumber;
   final Patient patient;
-  final bool animate;
+  final AnimateDirection animateDirection;
 
-  RequiredActionContainer(this.action, this.actionNumber, this.patient, {this.animate: false});
+  RequiredActionContainer(this.action, this.actionNumber, this.patient, {this.animateDirection});
 
   @override
   State<StatefulWidget> createState() => _RequiredActionContainerState();
@@ -51,12 +53,15 @@ class _RequiredActionContainerState extends State<RequiredActionContainer> with 
   }
 
   void _animateIfDemanded() {
-    if (widget.animate) {
+    if (widget.animateDirection == null) {
+      // do not animate and initialize animation to its end state
+      _controller.value = _controller.upperBound;
+    } else if (widget.animateDirection == AnimateDirection.FORWARD) {
       _controller.reset();
       _controller.forward();
-    } else {
-      // initialize animation to its end state
+    } else if (widget.animateDirection == AnimateDirection.BACKWARD) {
       _controller.value = _controller.upperBound;
+      _controller.animateBack(0.0, duration: Duration(milliseconds: 1000), curve: Curves.ease);
     }
   }
 

--- a/lib/components/RequiredActionContainer.dart
+++ b/lib/components/RequiredActionContainer.dart
@@ -14,8 +14,9 @@ class RequiredActionContainer extends StatefulWidget {
   final int actionNumber;
   final Patient patient;
   final AnimateDirection animateDirection;
+  final VoidCallback onAnimated;
 
-  RequiredActionContainer(this.action, this.actionNumber, this.patient, {this.animateDirection});
+  RequiredActionContainer(this.action, this.actionNumber, this.patient, {this.animateDirection, this.onAnimated});
 
   @override
   State<StatefulWidget> createState() => _RequiredActionContainerState();
@@ -63,6 +64,9 @@ class _RequiredActionContainerState extends State<RequiredActionContainer> with 
       _controller.value = _controller.upperBound;
       _controller.animateBack(0.0, duration: Duration(milliseconds: 1000), curve: Curves.ease);
     }
+    if (widget.onAnimated != null) {
+      widget.onAnimated();
+    }
   }
 
   dispose() {
@@ -73,7 +77,6 @@ class _RequiredActionContainerState extends State<RequiredActionContainer> with 
   FlatButton _endpointSurveyDoneButton(RequiredAction action) {
     return FlatButton(
       onPressed: () async {
-        widget.patient.requiredActions.removeWhere((RequiredAction a) => a.type == action.type);
         await DatabaseProvider().removeRequiredAction(widget.patient.artNumber, action.type);
         PatientBloc.instance.sinkRequiredActionData(action, true);
       },

--- a/lib/components/RequiredActionContainer.dart
+++ b/lib/components/RequiredActionContainer.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:pebrapp/database/DatabaseProvider.dart';
+import 'package:pebrapp/database/models/Patient.dart';
+import 'package:pebrapp/database/models/RequiredAction.dart';
+import 'package:pebrapp/state/PatientBloc.dart';
+import 'package:pebrapp/utils/AppColors.dart';
+import 'package:pebrapp/utils/VisibleImpactUtils.dart';
+
+class RequiredActionContainer extends StatefulWidget {
+
+  final RequiredAction action;
+  final int actionNumber;
+  final Patient patient;
+  final bool animate;
+
+  RequiredActionContainer(this.action, this.actionNumber, this.patient, {this.animate: false});
+
+  @override
+  State<StatefulWidget> createState() => _RequiredActionContainerState();
+
+}
+
+class _RequiredActionContainerState extends State<RequiredActionContainer> with SingleTickerProviderStateMixin {
+
+  AnimationController _controller;
+  Animation<double> _containerAnimation;
+  Curve _curve = Curves.ease;
+
+  @override
+  void initState() {
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 1000),
+      vsync: this,
+    );
+
+    _containerAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).chain(
+        CurveTween(curve: _curve)
+    ).animate(_controller);
+
+    _animateIfDemanded();
+    super.initState();
+  }
+
+  @override
+  void didUpdateWidget(RequiredActionContainer oldWidget) {
+    _animateIfDemanded();
+    super.didUpdateWidget(oldWidget);
+  }
+
+  void _animateIfDemanded() {
+    if (widget.animate) {
+      _controller.reset();
+      _controller.forward();
+    } else {
+      // initialize animation to its end state
+      _controller.value = _controller.upperBound;
+    }
+  }
+
+  dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  FlatButton _endpointSurveyDoneButton(RequiredAction action) {
+    return FlatButton(
+      onPressed: () async {
+        widget.patient.requiredActions.removeWhere((RequiredAction a) => a.type == action.type);
+        await DatabaseProvider().removeRequiredAction(widget.patient.artNumber, action.type);
+        PatientBloc.instance.sinkRequiredActionData(action, true);
+      },
+      splashColor: NOTIFICATION_INFO_SPLASH,
+      child: Text(
+        "ENDPOINT SURVEY COMPLETED",
+        style: TextStyle(
+          color: NOTIFICATION_INFO_TEXT,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    String actionText;
+    Widget actionButton;
+    switch (widget.action.type) {
+      case RequiredActionType.ASSESSMENT_REQUIRED:
+        actionText = "Preference assessment required. Start a preference assessment by tapping 'Start Assessment' below.";
+        break;
+      case RequiredActionType.REFILL_REQUIRED:
+        actionText = "ART refill required. Start an ART refill by tapping 'Manage Refill' below.";
+        break;
+      case RequiredActionType.ENDPOINT_3M_SURVEY_REQUIRED:
+        actionText = "3 month endpoint survey required. Start an endpoint survey by tapping 'Open KoBoCollect' below.";
+        actionButton = _endpointSurveyDoneButton(widget.action);
+        break;
+      case RequiredActionType.ENDPOINT_6M_SURVEY_REQUIRED:
+        actionText = "6 month endpoint survey required. Start an endpoint survey by tapping 'Open KoBoCollect' below.";
+        actionButton = _endpointSurveyDoneButton(widget.action);
+        break;
+      case RequiredActionType.ENDPOINT_12M_SURVEY_REQUIRED:
+        actionText = "12 month endpoint survey required. Start an endpoint survey by tapping 'Open KoBoCollect' below.";
+        actionButton = _endpointSurveyDoneButton(widget.action);
+        break;
+      case RequiredActionType.NOTIFICATIONS_UPLOAD_REQUIRED:
+        actionText = "The automatic synchronization of the notifications preferences with the database failed. Please synchronize manually.";
+        actionButton = FlatButton(
+          onPressed: () async {
+            await uploadNotificationsPreferences(widget.patient, widget.patient.latestPreferenceAssessment);
+          },
+          splashColor: NOTIFICATION_INFO_SPLASH,
+          child: Text(
+            "SYNCHRONIZE",
+            style: TextStyle(
+              color: NOTIFICATION_INFO_TEXT,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        );
+        break;
+      case RequiredActionType.ART_REFILL_DATE_UPLOAD_REQUIRED:
+        actionText = "The automatic synchronization of the ART refill date with the database failed. Please synchronize manually.";
+        actionButton = FlatButton(
+          onPressed: () async {
+            await uploadNextARTRefillDate(widget.patient, widget.patient.latestARTRefill.nextRefillDate);
+          },
+          splashColor: NOTIFICATION_INFO_SPLASH,
+          child: Text(
+            "SYNCHRONIZE",
+            style: TextStyle(
+              color: NOTIFICATION_INFO_TEXT,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        );
+        break;
+    }
+
+    final double badgeSize = 30.0;
+    return SizeTransition(
+      sizeFactor: _containerAnimation,
+      child: Card(
+        margin: const EdgeInsets.symmetric(horizontal: 15.0, vertical: 5.0),
+        elevation: 5.0,
+        clipBehavior: Clip.antiAlias,
+        child: Container(
+          color: NOTIFICATION_NORMAL,
+          padding: const EdgeInsets.symmetric(horizontal: 15.0),
+          child: Column(
+            children: [
+              SizedBox(height: 20.0),
+              Container(
+                width: double.infinity,
+                child: Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Hero(
+                        tag: "RequiredAction_${widget.patient.artNumber}_${widget.actionNumber}",
+                        child: Container(
+                          width: badgeSize,
+                          height: badgeSize,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: Colors.black,
+                          ),
+                          child: Center(
+                            child: Text(
+                              '${widget.actionNumber+1}',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 16.0,
+                                fontWeight: FontWeight.normal,
+                                fontFamily: 'Roboto',
+                                decoration: TextDecoration.none,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      SizedBox(width: 10.0),
+                      Expanded(
+                        child: Text(
+                          actionText,
+                          textAlign: TextAlign.left,
+                          style: TextStyle(
+                            color: NOTIFICATION_MESSAGE_TEXT,
+                            height: 1.2,
+                          ),
+                        ),
+                      ),
+                    ]),
+              ),
+              actionButton ?? SizedBox(height: 15.0),
+              SizedBox(height: 5.0),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+}

--- a/lib/database/DatabaseProvider.dart
+++ b/lib/database/DatabaseProvider.dart
@@ -869,7 +869,8 @@ class DatabaseProvider {
     final int rowsDeletedViralLoadTable = await db.delete(ViralLoad.tableName, where: '${ViralLoad.colPatientART} = ?', whereArgs: [artNumber]);
     final int rowsDeletedPreferenceAssessmentTable = await db.delete(PreferenceAssessment.tableName, where: '${PreferenceAssessment.colPatientART} = ?', whereArgs: [artNumber]);
     final int rowsDeletedARTRefillTable = await db.delete(ARTRefill.tableName, where: '${ARTRefill.colPatientART} = ?', whereArgs: [artNumber]);
-    return rowsDeletedPatientTable + rowsDeletedViralLoadTable + rowsDeletedPreferenceAssessmentTable + rowsDeletedARTRefillTable;
+    final int rowsDeletedRequiredActionTable = await db.delete(RequiredAction.tableName, where: '${RequiredAction.colPatientART} = ?', whereArgs: [artNumber]);
+    return rowsDeletedPatientTable + rowsDeletedViralLoadTable + rowsDeletedPreferenceAssessmentTable + rowsDeletedARTRefillTable + rowsDeletedRequiredActionTable;
   }
 
 }

--- a/lib/database/DatabaseProvider.dart
+++ b/lib/database/DatabaseProvider.dart
@@ -20,7 +20,7 @@ import 'package:pebrapp/utils/SwitchToolboxUtils.dart';
 class DatabaseProvider {
   // Increase the _DB_VERSION number if you made changes to the database schema.
   // An increase will call the [_onUpgrade] method.
-  static const int _DB_VERSION = 33;
+  static const int _DB_VERSION = 34;
   // Do not access the _database directly (it might be null), instead use the
   // _databaseInstance getter which will initialize the database if it is
   // uninitialized
@@ -191,6 +191,7 @@ class DatabaseProvider {
           ${RequiredAction.colCreatedDate} TEXT NOT NULL,
           ${RequiredAction.colPatientART} TEXT NOT NULL,
           ${RequiredAction.colType} INTEGER NOT NULL,
+          ${RequiredAction.colDueDate} TEXT NOT NULL,
           UNIQUE(${RequiredAction.colPatientART}, ${RequiredAction.colType}) ON CONFLICT IGNORE
         );
         """);
@@ -442,6 +443,10 @@ class DatabaseProvider {
           UNIQUE(patient_art, action_type) ON CONFLICT IGNORE
         );
         """);
+    }
+    if (oldVersion < 34) {
+      print('Upgrading to database version 34...');
+      await db.execute("ALTER TABLE RequiredAction ADD due_date TEXT NOT NULL DEFAULT '1970-01-01T00:00:00.000Z';");
     }
   }
 
@@ -769,7 +774,6 @@ class DatabaseProvider {
         RequiredAction.tableName,
         where: '${RequiredAction.colPatientART} = ?',
         whereArgs: [patientART],
-        orderBy: '${RequiredAction.colCreatedDate} DESC'
     );
     final Set<RequiredAction> set = {};
     for (Map map in res) {

--- a/lib/database/models/Patient.dart
+++ b/lib/database/models/Patient.dart
@@ -62,6 +62,7 @@ class Patient implements IExcelExportable {
   PreferenceAssessment latestPreferenceAssessment;
   ARTRefill latestARTRefill;
   Set<RequiredAction> requiredActions = {};
+  Set<RequiredAction> visibleRequiredActionsAtInitialization = {};
 
 
   // Constructors
@@ -223,6 +224,7 @@ class Patient implements IExcelExportable {
       actions.add(assessmentRequired);
     }
     this.requiredActions = actions;
+    this.visibleRequiredActionsAtInitialization = visibleRequiredActions;
   }
 
   /// Returns the viral load with the latest blood draw date.

--- a/lib/database/models/Patient.dart
+++ b/lib/database/models/Patient.dart
@@ -293,4 +293,19 @@ class Patient implements IExcelExportable {
   // ignore: unnecessary_getters_setters
   DateTime get createdDate => _createdDate;
 
+  /// Filters out endpoint survey actions that are not due yet.
+  Set<RequiredAction> get visibleRequiredActions {
+    Set<RequiredAction> visibleRequiredActions = {};
+    visibleRequiredActions.addAll(requiredActions);
+    visibleRequiredActions.removeWhere((RequiredAction a) {
+      final bool isEndpointSurveyAndDue = isEndpointSurveyDue(this.enrolmentDate, a.type);
+      if (isEndpointSurveyAndDue != null && !isEndpointSurveyAndDue) {
+        // endpoint survey not due yet, remove from visible required actions
+        return true;
+      }
+      return false;
+    });
+    return visibleRequiredActions;
+  }
+
 }

--- a/lib/database/models/Patient.dart
+++ b/lib/database/models/Patient.dart
@@ -208,21 +208,20 @@ class Patient implements IExcelExportable {
   /// initialized (null).
   Future<void> initializeRequiredActionsField() async {
     // get required actions stored in database
-    Set<RequiredAction> actions = await DatabaseProvider().retrieveRequiredActionsForPatient(artNumber);
-    // calculate other required actions
+    final Set<RequiredAction> actions = await DatabaseProvider().retrieveRequiredActionsForPatient(artNumber);
     final DateTime now = DateTime.now();
-    if (latestARTRefill?.nextRefillDate == null || now.isAfter(latestARTRefill.nextRefillDate)) {
-      RequiredAction artRefillRequired = RequiredAction(artNumber, RequiredActionType.REFILL_REQUIRED);
+    // calculate if ART refill is required
+    final DateTime dueDateART = latestARTRefill?.nextRefillDate;
+    if (dueDateART == null || now.isAfter(dueDateART)) {
+      RequiredAction artRefillRequired = RequiredAction(artNumber, RequiredActionType.REFILL_REQUIRED, dueDateART ?? enrolmentDate);
       actions.add(artRefillRequired);
     }
-    if (latestPreferenceAssessment == null || now.isAfter(calculateNextAssessment(latestPreferenceAssessment.createdDate, isSuppressed(this)))) {
-      RequiredAction assessmentRequired = RequiredAction(artNumber, RequiredActionType.ASSESSMENT_REQUIRED);
+    // calculate if preference assessment is required
+    final DateTime dueDatePA = calculateNextAssessment(latestPreferenceAssessment?.createdDate, isSuppressed(this));
+    if (dueDatePA == null || now.isAfter(dueDatePA)) {
+      RequiredAction assessmentRequired = RequiredAction(artNumber, RequiredActionType.ASSESSMENT_REQUIRED, dueDatePA ?? enrolmentDate);
       actions.add(assessmentRequired);
     }
-    // TODO: Check if a new endpoint survey is due and add to actions if it is.
-    //  We have to keep track of when the user finished an endpoint survey so we
-    //  don't display two messages after 6 months even though the user already
-    //  finished the 3-month survey.
     this.requiredActions = actions;
   }
 

--- a/lib/database/models/RequiredAction.dart
+++ b/lib/database/models/RequiredAction.dart
@@ -7,20 +7,23 @@ class RequiredAction {
   static final colCreatedDate = 'created_date_utc';
   static final colPatientART = 'patient_art'; // foreign key to [Patient].art_number
   static final colType = 'action_type';
+  static final colDueDate = 'due_date';
 
   DateTime _createdDate;
   String patientART;
   RequiredActionType type;
+  DateTime dueDate;
 
   // Constructors
   // ------------
 
-  RequiredAction(this.patientART, this.type);
+  RequiredAction(this.patientART, this.type, this.dueDate);
 
   RequiredAction.fromMap(map) {
     this._createdDate = DateTime.parse(map[colCreatedDate]);
     this.patientART = map[colPatientART];
     this.type = RequiredActionType.values[map[colType]];
+    this.dueDate = DateTime.parse(map[colDueDate]);
   }
 
 
@@ -28,6 +31,11 @@ class RequiredAction {
   // -----
 
   // override the equality operator
+  // we deliberately define RequiredActions to be equal if they belong to the
+  // same patient and are of the same type, we ignore different dueDates
+  // because we don't want to allow for duplicates of the same type (e.g. if
+  // there are several entries of NOTIFICATIONS_UPLOAD_REQUIRED we only want to
+  // require an upload from the user once and not display several such actions)
   @override
   bool operator ==(o) => o is RequiredAction && o.patientART == this.patientART && o.type == this.type;
 
@@ -40,6 +48,7 @@ class RequiredAction {
     map[colCreatedDate] = _createdDate.toIso8601String();
     map[colPatientART] = patientART;
     map[colType] = type.index;
+    map[colDueDate] = dueDate.toIso8601String();
     return map;
   }
 

--- a/lib/screens/ARTRefillScreen.dart
+++ b/lib/screens/ARTRefillScreen.dart
@@ -41,19 +41,20 @@ class ARTRefillScreen extends StatelessWidget {
   }
 
   void _onPressChangeDate(BuildContext context) async {
-    DateTime newDate = await _showDatePickerWithTitle(context, 'Select the Next ART Refill Date');
-    if (newDate != null) {
-      final ARTRefill artRefill = ARTRefill(this._patient.artNumber, RefillType.CHANGE_DATE(), nextRefillDate: newDate);
+    DateTime nextRefillDate = await _showDatePickerWithTitle(context, 'Select the Next ART Refill Date');
+    if (nextRefillDate != null) {
+      final ARTRefill artRefill = ARTRefill(this._patient.artNumber, RefillType.CHANGE_DATE(), nextRefillDate: nextRefillDate);
       await DatabaseProvider().insertARTRefill(artRefill);
       _patient.latestARTRefill = artRefill;
-      if (newDate.isAfter(DateTime.now())) {
+      final DateTime now = DateTime.now();
+      if (nextRefillDate.isAfter(now)) {
         // send an event indicating that the art refill was done
-        PatientBloc.instance.sinkRequiredActionData(RequiredAction(_patient.artNumber, RequiredActionType.REFILL_REQUIRED), true);
+        PatientBloc.instance.sinkRequiredActionData(RequiredAction(_patient.artNumber, RequiredActionType.REFILL_REQUIRED, null), true);
       } else {
         // send an event indicating that the art refill is overdue and has to be done
-        PatientBloc.instance.sinkRequiredActionData(RequiredAction(_patient.artNumber, RequiredActionType.REFILL_REQUIRED), false);
+        PatientBloc.instance.sinkRequiredActionData(RequiredAction(_patient.artNumber, RequiredActionType.REFILL_REQUIRED, nextRefillDate), false);
       }
-      uploadNextARTRefillDate(_patient, newDate);
+      uploadNextARTRefillDate(_patient, nextRefillDate);
       Navigator.of(context).popUntil((Route<dynamic> route) {
         return route.settings.name == '/patient';
       });
@@ -61,19 +62,20 @@ class ARTRefillScreen extends StatelessWidget {
   }
 
   void _onPressRefillDone(BuildContext context) async {
-    DateTime newDate = await _showDatePickerWithTitle(context, 'Select the Next ART Refill Date');
-    if (newDate != null) {
-      final ARTRefill artRefill = ARTRefill(this._patient.artNumber, RefillType.DONE(), nextRefillDate: newDate);
+    DateTime nextRefillDate = await _showDatePickerWithTitle(context, 'Select the Next ART Refill Date');
+    if (nextRefillDate != null) {
+      final ARTRefill artRefill = ARTRefill(this._patient.artNumber, RefillType.DONE(), nextRefillDate: nextRefillDate);
       await DatabaseProvider().insertARTRefill(artRefill);
       _patient.latestARTRefill = artRefill;
-      if (newDate.isAfter(DateTime.now())) {
+      final DateTime now = DateTime.now();
+      if (nextRefillDate.isAfter(now)) {
         // send an event indicating that the art refill was done
-        PatientBloc.instance.sinkRequiredActionData(RequiredAction(_patient.artNumber, RequiredActionType.REFILL_REQUIRED), true);
+        PatientBloc.instance.sinkRequiredActionData(RequiredAction(_patient.artNumber, RequiredActionType.REFILL_REQUIRED, null), true);
       } else {
         // send an event indicating that the art refill is overdue and has to be done
-        PatientBloc.instance.sinkRequiredActionData(RequiredAction(_patient.artNumber, RequiredActionType.REFILL_REQUIRED), false);
+        PatientBloc.instance.sinkRequiredActionData(RequiredAction(_patient.artNumber, RequiredActionType.REFILL_REQUIRED, nextRefillDate), false);
       }
-      uploadNextARTRefillDate(_patient, newDate);
+      uploadNextARTRefillDate(_patient, nextRefillDate);
       Navigator.of(context).popUntil((Route<dynamic> route) {
         return route.settings.name == '/patient';
       });

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -908,7 +908,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
       return Colors.transparent;
     }
 
-    if (patient.requiredActions.length > 0) {
+    if (patient.visibleRequiredActions.length > 0) {
       return URGENCY_HIGH;
     }
 

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -266,13 +266,13 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
   /// inform all listeners of the new data.
   Future<void> _recalculateRequiredActionsForAllPatients() async {
     for (Patient p in _patients) {
-      final int previousActions = p.visibleRequiredActions.length;
+      final Set<RequiredAction> previousActions = p.visibleRequiredActionsAtInitialization;
       await p.initializeRequiredActionsField();
-      final int newActions = p.visibleRequiredActions.length;
-      final bool shouldAnimate = previousActions != newActions;
-      shouldAnimateRequiredActionBadge[p.artNumber] = shouldAnimate;
+      final Set<RequiredAction> newActions = p.visibleRequiredActions;
+      final bool shouldAnimate = previousActions.length != newActions.length;
       if (shouldAnimate) {
-        PatientBloc.instance.sinkNewPatientData(p);
+        shouldAnimateRequiredActionBadge[p.artNumber] = shouldAnimate;
+        PatientBloc.instance.sinkNewPatientData(p, oldRequiredActions: previousActions);
       }
     }
   }

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -258,12 +258,12 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
 
   /// Checks if an ART refill, preference assessment, or endpoint survey has
   /// become due by re-calculating the required actions field for each patient.
-  /// It calls setState after each patient to trigger a rebuild of the
-  /// MainScreen and display the new data.
+  /// It send an [PatientBloc.AppStatePatientData] event for each patient to
+  /// inform all listeners of the new data.
   Future<void> _recalculateRequiredActionsForAllPatients() async {
     for (Patient p in _patients) {
       await p.initializeRequiredActionsField();
-      setState(() {});
+      PatientBloc.instance.sinkNewPatientData(p);
     }
   }
 

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -812,7 +812,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
       }
 
       // wrap in stack to display action required label
-      final int numOfActionsRequired = curPatient.requiredActions.length;
+      final int numOfActionsRequired = curPatient.visibleRequiredActions.length;
       if (curPatient.isActivated && numOfActionsRequired > 0) {
 
         final double badgeSize = 30.0;

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -117,11 +117,14 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
         Patient affectedPatient = _patients.singleWhere((Patient p) => p.artNumber == streamEvent.action.patientART, orElse: () => null);
         if (affectedPatient != null && !_patientScreenPushed) {
           setState(() {
-            // TODO: animate insertion and removal of required action label for visual fidelity
             if (streamEvent.isDone) {
+              shouldAnimateRequiredActionBadge[affectedPatient.artNumber] = true;
               affectedPatient.requiredActions.removeWhere((RequiredAction a) => a.type == streamEvent.action.type);
             } else {
-              affectedPatient.requiredActions.add(streamEvent.action);
+              if (affectedPatient.requiredActions.firstWhere((RequiredAction a) => a.type == streamEvent.action.type, orElse: () => null) == null) {
+                shouldAnimateRequiredActionBadge[affectedPatient.artNumber] = true;
+                affectedPatient.requiredActions.add(streamEvent.action);
+              }
             }
           });
         }

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -253,10 +253,18 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
   Future<void> _onAppResume() async {
     _checkLoggedInAndLockStatus();
     _runBackupIfDue();
-    // Check if an ART refill, preference assessment, or endpoint survey has
-    // become due. It is enough to trigger the MainScreen to rebuild, we do this
-    // by calling setState.
-    setState(() {});
+    _recalculateRequiredActionsForAllPatients();
+  }
+
+  /// Checks if an ART refill, preference assessment, or endpoint survey has
+  /// become due by re-calculating the required actions field for each patient.
+  /// It calls setState after each patient to trigger a rebuild of the
+  /// MainScreen and display the new data.
+  Future<void> _recalculateRequiredActionsForAllPatients() async {
+    for (Patient p in _patients) {
+      await p.initializeRequiredActionsField();
+      setState(() {});
+    }
   }
 
   /// Checks whether the user is logged in (if not shows the login screen) and

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -39,6 +39,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
   // TODO: remove _context field and pass context via args if necessary
   BuildContext _context;
   bool _isLoading = true;
+  bool _patientScreenPushed = false;
   List<Patient> _patients = [];
   StreamSubscription<AppState> _appStateStream;
   bool _loginLockCheckRunning = false;
@@ -114,11 +115,13 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
       if (streamEvent is AppStateRequiredActionData) {
         print('*** MainScreen received AppStateRequiredActionData: ${streamEvent.action.patientART} ***');
         Patient affectedPatient = _patients.singleWhere((Patient p) => p.artNumber == streamEvent.action.patientART, orElse: () => null);
-        if (affectedPatient != null) {
+        if (affectedPatient != null && !_patientScreenPushed) {
           setState(() {
             // TODO: animate insertion and removal of required action label for visual fidelity
             if (streamEvent.isDone) {
+              affectedPatient.requiredActions.removeWhere((RequiredAction a) => a.type == streamEvent.action.type);
             } else {
+              affectedPatient.requiredActions.add(streamEvent.action);
             }
           });
         }
@@ -420,6 +423,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
   }
 
   Future<void> _pushPatientScreen(Patient patient) async {
+    _patientScreenPushed = true;
     await Navigator.of(_context, rootNavigator: true).push(
       new MaterialPageRoute<void>(
         settings: RouteSettings(name: '/patient'),
@@ -428,6 +432,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
         },
       ),
     );
+    _patientScreenPushed = false;
   }
 
   Widget _bodyLoading() {

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -118,9 +118,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
           setState(() {
             // TODO: animate insertion and removal of required action label for visual fidelity
             if (streamEvent.isDone) {
-              affectedPatient.requiredActions.removeWhere((RequiredAction a) => a.type == streamEvent.action.type);
             } else {
-              affectedPatient.requiredActions.add(streamEvent.action);
             }
           });
         }

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -76,7 +76,6 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
      * https://github.com/flutter/flutter/issues/11655#issuecomment-348287396
      */
     _appStateStream = PatientBloc.instance.appState.listen( (streamEvent) {
-      print('*** MainScreen received data: ${streamEvent.runtimeType} ***');
       if (streamEvent is AppStateLoading) {
         setState(() {
           this._isLoading = true;

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -450,8 +450,14 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
   }
 
   Widget _bodyPatientTable() {
+    final double _paddingHorizontal = 10.0;
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
+      padding: EdgeInsets.only(
+        left: _paddingHorizontal,
+        right: _paddingHorizontal,
+        bottom: 10.0,
+      ),
       child: Column(
         children: _buildPatientCards(),
       ),
@@ -460,7 +466,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
 
   List<Widget> _buildPatientCards() {
     const _cardMarginVertical = 8.0;
-    const _cardMarginHorizontal = 10.0;
+    const _cardMarginHorizontal = 0.0;
     const _rowPaddingVertical = 20.0;
     const _rowPaddingHorizontal = 15.0;
     const _colorBarWidth = 15.0;
@@ -793,31 +799,22 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
           badges.add(
             Hero(
               tag: "RequiredAction_${curPatient.artNumber}_$i",
-              child: Padding(
-                padding: EdgeInsets.only(right: 3.0),
-                child: Container(
-                  width: badgeSize,
-                  height: badgeSize,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: Colors.black,
-                    boxShadow: [
-                      BoxShadow(
-                        color: i == 0 ? Colors.black45 : Colors.transparent,
-                        blurRadius: 10.0,
-                      ),
-                    ],
-                  ),
-                  child: Center(
-                    child: Text(
-                      '${i+1}',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 16.0,
-                        fontWeight: FontWeight.normal,
-                        fontFamily: 'Roboto',
-                        decoration: TextDecoration.none,
-                      ),
+              child: Container(
+                width: badgeSize,
+                height: badgeSize,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: Colors.black,
+                ),
+                child: Center(
+                  child: Text(
+                    '${i+1}',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 16.0,
+                      fontWeight: FontWeight.normal,
+                      fontFamily: 'Roboto',
+                      decoration: TextDecoration.none,
                     ),
                   ),
                 ),
@@ -827,7 +824,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
         }
 
         patientCard = Stack(
-          alignment: Alignment.topRight,
+          alignment: AlignmentDirectional(1.025, -1.0),
           children: <Widget>[
             patientCard,
             ...badges,

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -54,7 +54,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
     print('~~~ MainScreenState.initState ~~~');
     // listen to changes in the app lifecycle
     WidgetsBinding.instance.addObserver(this);
-    _onAppResume();
+    _onAppStart();
 
     /*
      * Normally, one uses StreamBuilder with the BLoC pattern. But StreamBuilder
@@ -236,11 +236,27 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
   /// Runs checks whether user is logged in / whether the app should be locked,
   /// and whether a backup should be run simultaneously.
   ///
-  /// Gets called when the application comes to the foreground or is run for the
-  /// first time.
+  /// Gets called when the application is started cold, i.e., when the app was
+  /// not open in the background already.
+  Future<void> _onAppStart() async {
+    _checkLoggedInAndLockStatus();
+    _runBackupIfDue();
+  }
+
+  /// Runs checks whether user is logged in / whether the app should be locked,
+  /// and whether a backup should be run simultaneously. It also rebuilds the
+  /// screen to update any changes to required actions, i.e., to check if any
+  /// ART refills, preference assessments, or endpoint surveys have become due.
+  ///
+  /// Gets called when the application was already open in the background and
+  /// comes to the foreground again.
   Future<void> _onAppResume() async {
     _checkLoggedInAndLockStatus();
     _runBackupIfDue();
+    // Check if an ART refill, preference assessment, or endpoint survey has
+    // become due. It is enough to trigger the MainScreen to rebuild, we do this
+    // by calling setState.
+    setState(() {});
   }
 
   /// Checks whether the user is logged in (if not shows the login screen) and

--- a/lib/screens/NewPatientScreen.dart
+++ b/lib/screens/NewPatientScreen.dart
@@ -717,7 +717,9 @@ class _NewPatientFormState extends State<_NewPatientForm> {
     });
     if (_formKey.currentState.validate() & _validateViralLoadBaselineDate()) {
 
-      _newPatient.enrolmentDate = DateTime.now().toUtc();
+      final DateTime now = DateTime.now();
+
+      _newPatient.enrolmentDate = now;
       _newPatient.isEligible = _eligible;
       _newPatient.artNumber = _artNumberCtr.text;
       _newPatient.stickerNumber = _stickerNumberCtr.text;
@@ -730,9 +732,9 @@ class _NewPatientFormState extends State<_NewPatientForm> {
       _newPatient.checkLogicAndResetUnusedFields();
 
       if (_newPatient.isEligible && _newPatient.consentGiven) {
-        await DatabaseProvider().insertRequiredAction(RequiredAction(_newPatient.artNumber, RequiredActionType.ENDPOINT_3M_SURVEY_REQUIRED));
-        await DatabaseProvider().insertRequiredAction(RequiredAction(_newPatient.artNumber, RequiredActionType.ENDPOINT_6M_SURVEY_REQUIRED));
-        await DatabaseProvider().insertRequiredAction(RequiredAction(_newPatient.artNumber, RequiredActionType.ENDPOINT_12M_SURVEY_REQUIRED));
+        await DatabaseProvider().insertRequiredAction(RequiredAction(_newPatient.artNumber, RequiredActionType.ENDPOINT_3M_SURVEY_REQUIRED, addMonths(now, 3)));
+        await DatabaseProvider().insertRequiredAction(RequiredAction(_newPatient.artNumber, RequiredActionType.ENDPOINT_6M_SURVEY_REQUIRED, addMonths(now, 6)));
+        await DatabaseProvider().insertRequiredAction(RequiredAction(_newPatient.artNumber, RequiredActionType.ENDPOINT_12M_SURVEY_REQUIRED, addMonths(now, 12)));
       }
 
       if (_newPatient.isEligible && _newPatient.consentGiven && _newPatient.isVLBaselineAvailable != null && _newPatient.isVLBaselineAvailable) {

--- a/lib/screens/NewPatientScreen.dart
+++ b/lib/screens/NewPatientScreen.dart
@@ -8,6 +8,7 @@ import 'package:pebrapp/database/beans/PhoneAvailability.dart';
 import 'package:pebrapp/database/beans/SexualOrientation.dart';
 import 'package:pebrapp/database/beans/ViralLoadSource.dart';
 import 'package:pebrapp/database/models/Patient.dart';
+import 'package:pebrapp/database/models/RequiredAction.dart';
 import 'package:pebrapp/database/models/ViralLoad.dart';
 import 'package:pebrapp/state/PatientBloc.dart';
 import 'package:pebrapp/utils/AppColors.dart';
@@ -727,6 +728,12 @@ class _NewPatientFormState extends State<_NewPatientForm> {
       _newPatient.village = _villageCtr.text;
       _newPatient.village = _villageCtr.text;
       _newPatient.checkLogicAndResetUnusedFields();
+
+      if (_newPatient.isEligible && _newPatient.consentGiven) {
+        await DatabaseProvider().insertRequiredAction(RequiredAction(_newPatient.artNumber, RequiredActionType.ENDPOINT_3M_SURVEY_REQUIRED));
+        await DatabaseProvider().insertRequiredAction(RequiredAction(_newPatient.artNumber, RequiredActionType.ENDPOINT_6M_SURVEY_REQUIRED));
+        await DatabaseProvider().insertRequiredAction(RequiredAction(_newPatient.artNumber, RequiredActionType.ENDPOINT_12M_SURVEY_REQUIRED));
+      }
 
       if (_newPatient.isEligible && _newPatient.consentGiven && _newPatient.isVLBaselineAvailable != null && _newPatient.isVLBaselineAvailable) {
         _viralLoadBaseline.patientART = _artNumberCtr.text;

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -64,7 +64,7 @@ class _PatientScreenState extends State<PatientScreen> {
       if (streamEvent is AppStateRequiredActionData && streamEvent.action.patientART == _patient.artNumber) {
         print('*** PatientScreen received AppStateRequiredActionData: ${streamEvent.action.patientART} ***');
         setState(() {
-          // TODO: animate insertion and removal of required action label for visual fidelity
+          // TODO: animate insertion and removal of required action card for visual fidelity
           if (streamEvent.isDone) {
             _patient.requiredActions.removeWhere((RequiredAction a) => a.type == streamEvent.action.type);
           } else {
@@ -146,7 +146,7 @@ class _PatientScreenState extends State<PatientScreen> {
         onPressed: () async {
           _patient.requiredActions.removeWhere((RequiredAction a) => a.type == action.type);
           await DatabaseProvider().removeRequiredAction(_patient.artNumber, action.type);
-          // TODO: hide the action card, ideally with an animation for visual fidelity
+          PatientBloc.instance.sinkRequiredActionData(action, true);
         },
         splashColor: NOTIFICATION_INFO_SPLASH,
         child: Text(
@@ -186,7 +186,6 @@ class _PatientScreenState extends State<PatientScreen> {
           actionButton = FlatButton(
             onPressed: () async {
               await uploadNotificationsPreferences(_patient, _patient.latestPreferenceAssessment);
-              // TODO: hide the action card if the upload was successful, ideally with an animation for visual fidelity
             },
             splashColor: NOTIFICATION_INFO_SPLASH,
             child: Text(
@@ -203,7 +202,6 @@ class _PatientScreenState extends State<PatientScreen> {
           actionButton = FlatButton(
             onPressed: () async {
               await uploadNextARTRefillDate(_patient, _patient.latestARTRefill.nextRefillDate);
-              // TODO: hide the action card if the upload was successful, ideally with an animation for visual fidelity
             },
             splashColor: NOTIFICATION_INFO_SPLASH,
             child: Text(

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -3,9 +3,9 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:pebrapp/components/PEBRAButtonFlat.dart';
 import 'package:pebrapp/components/PEBRAButtonRaised.dart';
+import 'package:pebrapp/components/RequiredActionContainer.dart';
 import 'package:pebrapp/components/TransparentHeaderPage.dart';
 import 'package:pebrapp/components/ViralLoadBadge.dart';
-import 'package:pebrapp/database/DatabaseProvider.dart';
 import 'package:pebrapp/database/beans/ARTRefillOption.dart';
 import 'package:pebrapp/database/beans/Gender.dart';
 import 'package:pebrapp/database/beans/SupportPreferencesSelection.dart';
@@ -21,7 +21,6 @@ import 'package:pebrapp/screens/PreferenceAssessmentScreen.dart';
 import 'package:pebrapp/state/PatientBloc.dart';
 import 'package:pebrapp/utils/AppColors.dart';
 import 'package:pebrapp/utils/Utils.dart';
-import 'package:pebrapp/utils/VisibleImpactUtils.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class PatientScreen extends StatefulWidget {
@@ -52,6 +51,7 @@ class _PatientScreenState extends State<PatientScreen> {
   StreamSubscription<AppState> _appStateStream;
 
   final double _spacingBetweenCards = 40.0;
+  final Map<RequiredActionType, bool> shouldAnimateRequiredActionContainer = {};
 
   // constructor
   _PatientScreenState(this._patient);
@@ -63,7 +63,11 @@ class _PatientScreenState extends State<PatientScreen> {
       print('*** PatientScreen received data: ${streamEvent.runtimeType} ***');
       if (streamEvent is AppStatePatientData && streamEvent.patient.artNumber == _patient.artNumber) {
         // TODO: animate changes to the new patient data (e.g. insertions and removals of required action card) with an animation for visual fidelity
-        print('*** PatientScreen received AppStatePatientData ***');
+        print('*** PatientScreen received AppStatePatientData: ${streamEvent.patient.artNumber} ***');
+        final Set<RequiredAction> newVisibleRequiredActions = streamEvent.patient.visibleRequiredActions;
+        for (RequiredAction a in newVisibleRequiredActions) {
+          shouldAnimateRequiredActionContainer[a.type] = streamEvent.oldRequiredActions != null && !streamEvent.oldRequiredActions.contains(a);
+        }
         setState(() {});
       }
       if (streamEvent is AppStateRequiredActionData && streamEvent.action.patientART == _patient.artNumber) {
@@ -146,144 +150,20 @@ class _PatientScreenState extends State<PatientScreen> {
 
   Widget _buildRequiredActions() {
 
-    FlatButton _endpointSurveyDoneButton(RequiredAction action) {
-      return FlatButton(
-        onPressed: () async {
-          _patient.requiredActions.removeWhere((RequiredAction a) => a.type == action.type);
-          await DatabaseProvider().removeRequiredAction(_patient.artNumber, action.type);
-          PatientBloc.instance.sinkRequiredActionData(action, true);
-        },
-        splashColor: NOTIFICATION_INFO_SPLASH,
-        child: Text(
-          "ENDPOINT SURVEY COMPLETED",
-          style: TextStyle(
-            color: NOTIFICATION_INFO_TEXT,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-      );
-    }
-
     final List<RequiredAction> visibleRequiredActionsSorted =_patient.visibleRequiredActions.toList();
     visibleRequiredActionsSorted.sort((RequiredAction a, RequiredAction b) => a.dueDate.isBefore(b.dueDate) ? -1 : 1);
     final actions = visibleRequiredActionsSorted.asMap().map((int i, RequiredAction action) {
-      String actionText;
-      Widget actionButton;
-      switch (action.type) {
-        case RequiredActionType.ASSESSMENT_REQUIRED:
-          actionText = "Preference assessment required. Start a preference assessment by tapping 'Start Assessment' below.";
-          break;
-        case RequiredActionType.REFILL_REQUIRED:
-          actionText = "ART refill required. Start an ART refill by tapping 'Manage Refill' below.";
-          break;
-        case RequiredActionType.ENDPOINT_3M_SURVEY_REQUIRED:
-          actionText = "3 month endpoint survey required. Start an endpoint survey by tapping 'Open KoBoCollect' below.";
-          actionButton = _endpointSurveyDoneButton(action);
-          break;
-        case RequiredActionType.ENDPOINT_6M_SURVEY_REQUIRED:
-          actionText = "6 month endpoint survey required. Start an endpoint survey by tapping 'Open KoBoCollect' below.";
-          actionButton = _endpointSurveyDoneButton(action);
-          break;
-        case RequiredActionType.ENDPOINT_12M_SURVEY_REQUIRED:
-          actionText = "12 month endpoint survey required. Start an endpoint survey by tapping 'Open KoBoCollect' below.";
-          actionButton = _endpointSurveyDoneButton(action);
-          break;
-        case RequiredActionType.NOTIFICATIONS_UPLOAD_REQUIRED:
-          actionText = "The automatic synchronization of the notifications preferences with the database failed. Please synchronize manually.";
-          actionButton = FlatButton(
-            onPressed: () async {
-              await uploadNotificationsPreferences(_patient, _patient.latestPreferenceAssessment);
-            },
-            splashColor: NOTIFICATION_INFO_SPLASH,
-            child: Text(
-              "SYNCHRONIZE",
-              style: TextStyle(
-                color: NOTIFICATION_INFO_TEXT,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-          );
-          break;
-        case RequiredActionType.ART_REFILL_DATE_UPLOAD_REQUIRED:
-          actionText = "The automatic synchronization of the ART refill date with the database failed. Please synchronize manually.";
-          actionButton = FlatButton(
-            onPressed: () async {
-              await uploadNextARTRefillDate(_patient, _patient.latestARTRefill.nextRefillDate);
-            },
-            splashColor: NOTIFICATION_INFO_SPLASH,
-            child: Text(
-              "SYNCHRONIZE",
-              style: TextStyle(
-                color: NOTIFICATION_INFO_TEXT,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-          );
-          break;
-      }
-
-      final double badgeSize = 30.0;
-      return MapEntry(
+      final mapEntry = MapEntry(
         i,
-        Card(
-          margin: const EdgeInsets.symmetric(horizontal: 15.0, vertical: 5.0),
-          elevation: 5.0,
-          clipBehavior: Clip.antiAlias,
-          child: Container(
-            color: NOTIFICATION_NORMAL,
-            padding: const EdgeInsets.symmetric(horizontal: 15.0),
-            child: Column(
-              children: [
-                SizedBox(height: 20.0),
-                Container(
-                  width: double.infinity,
-                  child: Row(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Hero(
-                          tag: "RequiredAction_${_patient.artNumber}_$i",
-                          child: Container(
-                            width: badgeSize,
-                            height: badgeSize,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: Colors.black,
-                            ),
-                            child: Center(
-                              child: Text(
-                                '${i+1}',
-                                style: TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 16.0,
-                                  fontWeight: FontWeight.normal,
-                                  fontFamily: 'Roboto',
-                                  decoration: TextDecoration.none,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                        SizedBox(width: 10.0),
-                        Expanded(
-                          child: Text(
-                            actionText,
-                            textAlign: TextAlign.left,
-                            style: TextStyle(
-                              color: NOTIFICATION_MESSAGE_TEXT,
-                              height: 1.2,
-                            ),
-                          ),
-                        ),
-                      ]),
-                ),
-                actionButton ?? SizedBox(height: 15.0),
-                SizedBox(height: 5.0),
-              ],
-            ),
-          ),
+        RequiredActionContainer(
+          action,
+          i,
+          _patient,
+          animate: shouldAnimateRequiredActionContainer[action.type] ?? false,
         ),
       );
+      shouldAnimateRequiredActionContainer[action.type] = false;
+      return mapEntry;
     }).values.toList();
 
     return Column(

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -61,6 +61,11 @@ class _PatientScreenState extends State<PatientScreen> {
     super.initState();
     _appStateStream = PatientBloc.instance.appState.listen( (streamEvent) {
       print('*** PatientScreen received data: ${streamEvent.runtimeType} ***');
+      if (streamEvent is AppStatePatientData && streamEvent.patient.artNumber == _patient.artNumber) {
+        // TODO: animate changes to the new patient data (e.g. insertions and removals of required action card) with an animation for visual fidelity
+        print('*** PatientScreen received AppStatePatientData ***');
+        setState(() {});
+      }
       if (streamEvent is AppStateRequiredActionData && streamEvent.action.patientART == _patient.artNumber) {
         print('*** PatientScreen received AppStateRequiredActionData: ${streamEvent.action.patientART} ***');
         setState(() {

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -76,11 +76,12 @@ class _PatientScreenState extends State<PatientScreen> {
         setState(() {
           // TODO: animate insertion and removal of required action card for visual fidelity
           if (streamEvent.isDone) {
-            _patient.requiredActions.removeWhere((RequiredAction a) => a.type == streamEvent.action.type);
             shouldAnimateRequiredActionContainer[streamEvent.action.type] = AnimateDirection.BACKWARD;
           } else {
-            _patient.requiredActions.add(streamEvent.action);
-            shouldAnimateRequiredActionContainer[streamEvent.action.type] = AnimateDirection.FORWARD;
+            if (_patient.requiredActions.firstWhere((RequiredAction a) => a.type == streamEvent.action.type, orElse: () => null) == null) {
+              shouldAnimateRequiredActionContainer[streamEvent.action.type] = AnimateDirection.FORWARD;
+              _patient.requiredActions.add(streamEvent.action);
+            }
           }
         });
       }
@@ -163,6 +164,9 @@ class _PatientScreenState extends State<PatientScreen> {
           i,
           _patient,
           animateDirection: shouldAnimateRequiredActionContainer[action.type],
+          onAnimated: () {
+            _patient.initializeRequiredActionsField();
+          },
         ),
       );
       shouldAnimateRequiredActionContainer[action.type] = null;

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -60,7 +60,6 @@ class _PatientScreenState extends State<PatientScreen> {
   void initState() {
     super.initState();
     _appStateStream = PatientBloc.instance.appState.listen( (streamEvent) {
-      print('*** PatientScreen received data: ${streamEvent.runtimeType} ***');
       if (streamEvent is AppStatePatientData && streamEvent.patient.artNumber == _patient.artNumber) {
         // TODO: animate changes to the new patient data (e.g. insertions and removals of required action card) with an animation for visual fidelity
         print('*** PatientScreen received AppStatePatientData: ${streamEvent.patient.artNumber} ***');

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -159,7 +159,9 @@ class _PatientScreenState extends State<PatientScreen> {
       );
     }
 
-    final actions = _patient.visibleRequiredActions.toList().asMap().map((int i, RequiredAction action) {
+    final List<RequiredAction> visibleRequiredActionsSorted =_patient.visibleRequiredActions.toList();
+    visibleRequiredActionsSorted.sort((RequiredAction a, RequiredAction b) => a.dueDate.isBefore(b.dueDate) ? -1 : 1);
+    final actions = visibleRequiredActionsSorted.asMap().map((int i, RequiredAction action) {
       String actionText;
       Widget actionButton;
       switch (action.type) {

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -100,7 +100,7 @@ class _PatientScreenState extends State<PatientScreen> {
       _nextRefillText = '—';
     }
 
-    DateTime nextEndpointSurveyDate = calculateNextEndpointSurvey(_patient.enrolmentDate);
+    DateTime nextEndpointSurveyDate = calculateNextEndpointSurvey(_patient.enrolmentDate, _patient.requiredActions);
     if (nextEndpointSurveyDate != null) {
       _nextEndpointText = formatDate(nextEndpointSurveyDate);
     } else {
@@ -159,7 +159,7 @@ class _PatientScreenState extends State<PatientScreen> {
       );
     }
 
-    final actions = _patient.requiredActions.toList().asMap().map((int i, RequiredAction action) {
+    final actions = _patient.visibleRequiredActions.toList().asMap().map((int i, RequiredAction action) {
       String actionText;
       Widget actionButton;
       switch (action.type) {

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -51,7 +51,7 @@ class _PatientScreenState extends State<PatientScreen> {
   StreamSubscription<AppState> _appStateStream;
 
   final double _spacingBetweenCards = 40.0;
-  final Map<RequiredActionType, bool> shouldAnimateRequiredActionContainer = {};
+  final Map<RequiredActionType, AnimateDirection> shouldAnimateRequiredActionContainer = {};
 
   // constructor
   _PatientScreenState(this._patient);
@@ -66,7 +66,9 @@ class _PatientScreenState extends State<PatientScreen> {
         print('*** PatientScreen received AppStatePatientData: ${streamEvent.patient.artNumber} ***');
         final Set<RequiredAction> newVisibleRequiredActions = streamEvent.patient.visibleRequiredActions;
         for (RequiredAction a in newVisibleRequiredActions) {
-          shouldAnimateRequiredActionContainer[a.type] = streamEvent.oldRequiredActions != null && !streamEvent.oldRequiredActions.contains(a);
+          if (streamEvent.oldRequiredActions != null && !streamEvent.oldRequiredActions.contains(a)) {
+            shouldAnimateRequiredActionContainer[a.type] = AnimateDirection.FORWARD;
+          }
         }
         setState(() {});
       }
@@ -76,8 +78,10 @@ class _PatientScreenState extends State<PatientScreen> {
           // TODO: animate insertion and removal of required action card for visual fidelity
           if (streamEvent.isDone) {
             _patient.requiredActions.removeWhere((RequiredAction a) => a.type == streamEvent.action.type);
+            shouldAnimateRequiredActionContainer[streamEvent.action.type] = AnimateDirection.BACKWARD;
           } else {
             _patient.requiredActions.add(streamEvent.action);
+            shouldAnimateRequiredActionContainer[streamEvent.action.type] = AnimateDirection.FORWARD;
           }
         });
       }
@@ -159,10 +163,10 @@ class _PatientScreenState extends State<PatientScreen> {
           action,
           i,
           _patient,
-          animate: shouldAnimateRequiredActionContainer[action.type] ?? false,
+          animateDirection: shouldAnimateRequiredActionContainer[action.type],
         ),
       );
-      shouldAnimateRequiredActionContainer[action.type] = false;
+      shouldAnimateRequiredActionContainer[action.type] = null;
       return mapEntry;
     }).values.toList();
 

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -73,17 +73,21 @@ class _PatientScreenState extends State<PatientScreen> {
       }
       if (streamEvent is AppStateRequiredActionData && streamEvent.action.patientART == _patient.artNumber) {
         print('*** PatientScreen received AppStateRequiredActionData: ${streamEvent.action.patientART} ***');
-        setState(() {
           // TODO: animate insertion and removal of required action card for visual fidelity
           if (streamEvent.isDone) {
-            shouldAnimateRequiredActionContainer[streamEvent.action.type] = AnimateDirection.BACKWARD;
+            if (_patient.requiredActions.firstWhere((RequiredAction a) => a.type == streamEvent.action.type, orElse: () => null) != null) {
+              setState(() {
+                shouldAnimateRequiredActionContainer[streamEvent.action.type] = AnimateDirection.BACKWARD;
+              });
+            }
           } else {
             if (_patient.requiredActions.firstWhere((RequiredAction a) => a.type == streamEvent.action.type, orElse: () => null) == null) {
-              shouldAnimateRequiredActionContainer[streamEvent.action.type] = AnimateDirection.FORWARD;
-              _patient.requiredActions.add(streamEvent.action);
+              setState(() {
+                shouldAnimateRequiredActionContainer[streamEvent.action.type] = AnimateDirection.FORWARD;
+                _patient.requiredActions.add(streamEvent.action);
+              });
             }
           }
-        });
       }
     });
   }

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -100,8 +100,7 @@ class _PatientScreenState extends State<PatientScreen> {
       _nextRefillText = '—';
     }
 
-    DateTime nextEndpointSurveyDate = _patient.enrolmentDate;
-    nextEndpointSurveyDate = calculateNextEndpointSurvey(nextEndpointSurveyDate);
+    DateTime nextEndpointSurveyDate = calculateNextEndpointSurvey(_patient.enrolmentDate);
     if (nextEndpointSurveyDate != null) {
       _nextEndpointText = formatDate(nextEndpointSurveyDate);
     } else {

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -169,11 +169,12 @@ class _PatientScreenState extends State<PatientScreen> {
           _patient,
           animateDirection: shouldAnimateRequiredActionContainer[action.type],
           onAnimated: () {
-            _patient.initializeRequiredActionsField();
+            setState(() {});
           },
         ),
       );
       shouldAnimateRequiredActionContainer[action.type] = null;
+      _patient.initializeRequiredActionsField();
       return mapEntry;
     }).values.toList();
 

--- a/lib/screens/PreferenceAssessmentScreen.dart
+++ b/lib/screens/PreferenceAssessmentScreen.dart
@@ -2237,7 +2237,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
         DatabaseProvider().insertUserData(_user);
       }
       // send an event indicating that the preference assessment was done
-      PatientBloc.instance.sinkRequiredActionData(RequiredAction(_patient.artNumber, RequiredActionType.ASSESSMENT_REQUIRED), true);
+      PatientBloc.instance.sinkRequiredActionData(RequiredAction(_patient.artNumber, RequiredActionType.ASSESSMENT_REQUIRED, null), true);
       uploadNotificationsPreferences(_patient, _pa);
       Navigator.of(context).pop(); // close Preference Assessment screen
       showFlushbar('Preference Assessment saved');

--- a/lib/state/PatientBloc.dart
+++ b/lib/state/PatientBloc.dart
@@ -48,9 +48,9 @@ class PatientBloc {
   }
 
   /// Trigger an [AppStatePatientData] stream event.
-  Future<void> sinkNewPatientData(Patient patient) async {
+  Future<void> sinkNewPatientData(Patient patient, {Set<RequiredAction> oldRequiredActions}) async {
     print('Putting patient ${patient.artNumber} down the sink');
-    _appStateStreamController.sink.add(AppStatePatientData(patient));
+    _appStateStreamController.sink.add(AppStatePatientData(patient, oldRequiredActions: oldRequiredActions));
   }
 
   /// Trigger an [AppStateRequiredActionData] stream event.
@@ -75,7 +75,8 @@ class AppStateNoData extends AppState {}
 
 class AppStatePatientData extends AppState {
   final Patient patient;
-  AppStatePatientData(this.patient);
+  final Set<RequiredAction> oldRequiredActions;
+  AppStatePatientData(this.patient, {this.oldRequiredActions});
 }
 
 class AppStateRequiredActionData extends AppState {

--- a/lib/utils/Utils.dart
+++ b/lib/utils/Utils.dart
@@ -332,7 +332,7 @@ bool isSuppressed(Patient patient) {
 
 /// Shows the lock screen, where the user has to enter their PIN code to unlock.
 Future<T> lockApp<T extends Object>(BuildContext context) {
-  return Navigator.of(context).push(
+  return Navigator.of(context, rootNavigator: true).push(
     PageRouteBuilder<T>(
       opaque: false,
       settings: RouteSettings(name: '/lock'),

--- a/lib/utils/Utils.dart
+++ b/lib/utils/Utils.dart
@@ -211,15 +211,15 @@ DateTime calculateNextEndpointSurvey(DateTime enrollmentDate, Set<RequiredAction
   final bool _completed3M = !requiredActions.any((RequiredAction a) => a.type == RequiredActionType.ENDPOINT_3M_SURVEY_REQUIRED);
   DateTime nextDate;
   if (!_completed12M) {
-    DateTime twelveMonthsAfter = _addMonths(enrollmentDate, 12);
+    DateTime twelveMonthsAfter = addMonths(enrollmentDate, 12);
     nextDate = twelveMonthsAfter;
   }
   if (!_completed6M) {
-    DateTime sixMonthsAfter = _addMonths(enrollmentDate, 6);
+    DateTime sixMonthsAfter = addMonths(enrollmentDate, 6);
     nextDate = sixMonthsAfter;
   }
   if (!_completed3M) {
-    DateTime threeMonthsAfter = _addMonths(enrollmentDate, 3);
+    DateTime threeMonthsAfter = addMonths(enrollmentDate, 3);
     nextDate = threeMonthsAfter;
   }
   return nextDate;
@@ -234,20 +234,23 @@ bool isEndpointSurveyDue(DateTime enrollmentDate, RequiredActionType endpointSur
   final DateTime now = DateTime.now();
   switch (endpointSurveyType) {
     case RequiredActionType.ENDPOINT_12M_SURVEY_REQUIRED:
-      final DateTime twelveMonthsAfter = _addMonths(enrollmentDate, 12);
+      final DateTime twelveMonthsAfter = addMonths(enrollmentDate, 12);
       return now.isAfter(twelveMonthsAfter);
     case RequiredActionType.ENDPOINT_6M_SURVEY_REQUIRED:
-      final DateTime sixMonthsAfter = _addMonths(enrollmentDate, 6);
+      final DateTime sixMonthsAfter = addMonths(enrollmentDate, 6);
       return now.isAfter(sixMonthsAfter);
     case RequiredActionType.ENDPOINT_3M_SURVEY_REQUIRED:
-      final DateTime threeMonthsAfter = _addMonths(enrollmentDate, 3);
+      final DateTime threeMonthsAfter = addMonths(enrollmentDate, 3);
       return now.isAfter(threeMonthsAfter);
     default:
       return null;
   }
 }
 
-DateTime _addMonths(DateTime date, int monthsToAdd) {
+/// Adds [monthsToAdd] to [date].
+///
+/// Hour, minute, second, millisecond, microsecond will all be 0.
+DateTime addMonths(DateTime date, int monthsToAdd) {
   return DateTime(date.year, date.month + monthsToAdd, date.day);
 }
 

--- a/lib/utils/VisibleImpactUtils.dart
+++ b/lib/utils/VisibleImpactUtils.dart
@@ -50,14 +50,12 @@ Future<void> uploadNotificationsPreferences(Patient patient, PreferenceAssessmen
 
 Future<void> _handleSuccess(Patient patient, RequiredActionType actionType) async {
   print('$actionType uploaded to visible impact database successfully.');
-  patient.requiredActions.removeWhere((RequiredAction action) => action.type == actionType);
   await DatabaseProvider().removeRequiredAction(patient.artNumber, actionType);
   PatientBloc.instance.sinkRequiredActionData(RequiredAction(patient.artNumber, actionType, null), true);
 }
 
 Future<void> _handleFailure(Patient patient, RequiredActionType actionType) async {
   final newAction = RequiredAction(patient.artNumber, actionType, DateTime.now());
-  patient.requiredActions.add(newAction);
   await DatabaseProvider().insertRequiredAction(newAction);
   PatientBloc.instance.sinkRequiredActionData(newAction, false);
 }

--- a/lib/utils/VisibleImpactUtils.dart
+++ b/lib/utils/VisibleImpactUtils.dart
@@ -52,12 +52,12 @@ Future<void> _handleSuccess(Patient patient, RequiredActionType actionType) asyn
   print('$actionType uploaded to visible impact database successfully.');
   patient.requiredActions.removeWhere((RequiredAction action) => action.type == actionType);
   await DatabaseProvider().removeRequiredAction(patient.artNumber, actionType);
-  PatientBloc.instance.sinkRequiredActionData(RequiredAction(patient.artNumber, actionType), true);
+  PatientBloc.instance.sinkRequiredActionData(RequiredAction(patient.artNumber, actionType, null), true);
 }
 
 Future<void> _handleFailure(Patient patient, RequiredActionType actionType) async {
-  final newAction = RequiredAction(patient.artNumber, actionType);
+  final newAction = RequiredAction(patient.artNumber, actionType, DateTime.now());
   patient.requiredActions.add(newAction);
   await DatabaseProvider().insertRequiredAction(newAction);
-  PatientBloc.instance.sinkRequiredActionData(RequiredAction(patient.artNumber, actionType), false);
+  PatientBloc.instance.sinkRequiredActionData(newAction, false);
 }


### PR DESCRIPTION
closes #18 

- remind of endpoint survey 3, 6, and 12 months after patient enrollment
- animate new and disappearing required actions on main screen and on patient screen
- on narrow devices on main screen, scroll entire table horizontally instead of just single patient card
- fixed a lock screen bug