### PR TITLE
29 support option done

### DIFF
--- a/lib/database/DatabaseProvider.dart
+++ b/lib/database/DatabaseProvider.dart
@@ -5,6 +5,7 @@ import 'package:pebrapp/database/beans/RefillType.dart';
 import 'package:pebrapp/database/models/ARTRefill.dart';
 import 'package:pebrapp/database/models/RequiredAction.dart';
 import 'package:pebrapp/database/models/Patient.dart';
+import 'package:pebrapp/database/models/SupportOptionDone.dart';
 import 'package:pebrapp/database/models/UserData.dart';
 import 'package:pebrapp/database/models/ViralLoad.dart';
 import 'package:pebrapp/database/models/PreferenceAssessment.dart';
@@ -20,7 +21,7 @@ import 'package:pebrapp/utils/SwitchToolboxUtils.dart';
 class DatabaseProvider {
   // Increase the _DB_VERSION number if you made changes to the database schema.
   // An increase will call the [_onUpgrade] method.
-  static const int _DB_VERSION = 46;
+  static const int _DB_VERSION = 47;
   // Do not access the _database directly (it might be null), instead use the
   // _databaseInstance getter which will initialize the database if it is
   // uninitialized
@@ -189,6 +190,15 @@ class DatabaseProvider {
           ${RequiredAction.colType} INTEGER NOT NULL,
           ${RequiredAction.colDueDate} TEXT NOT NULL,
           UNIQUE(${RequiredAction.colPatientART}, ${RequiredAction.colType}) ON CONFLICT IGNORE
+        );
+        """);
+    await db.execute("""
+        CREATE TABLE IF NOT EXISTS ${SupportOptionDone.tableName} (
+          ${SupportOptionDone.colId} INTEGER PRIMARY KEY,
+          ${SupportOptionDone.colCreatedDate} TEXT NOT NULL,
+          ${SupportOptionDone.colPreferenceAssessmentId} INTEGER NOT NULL,
+          ${SupportOptionDone.colSupportOption} INTEGER NOT NULL,
+          ${SupportOptionDone.colDone} BIT NOT NULL
         );
         """);
     // TODO: set colLatestPreferenceAssessment as foreign key to `PreferenceAssessment` table
@@ -538,6 +548,18 @@ class DatabaseProvider {
       await db.execute("DROP TABLE IF EXISTS ViralLoad;");
       await _onCreate(db, 46);
     }
+    if (oldVersion < 47 && _DB_VERSION >= 47) {
+      print('Upgrading to database version 47...');
+      await db.execute("""
+        CREATE TABLE IF NOT EXISTS SupportOptionDone (
+          id INTEGER PRIMARY KEY,
+          created_date TEXT NOT NULL,
+          preference_assessment_id INTEGER NOT NULL,
+          support_option INTEGER NOT NULL,
+          done BIT NOT NULL
+        );
+        """);
+    }
   }
 
   FutureOr<void> _onDowngrade(Database db, int oldVersion, int newVersion) async {
@@ -793,7 +815,9 @@ class DatabaseProvider {
         orderBy: '${PreferenceAssessment.colCreatedDate} DESC'
     );
     if (res.length > 0) {
-      return PreferenceAssessment.fromMap(res.first);
+      final PreferenceAssessment pa = PreferenceAssessment.fromMap(res.first);
+      await pa.initializeSupportOptionDoneFields();
+      return pa;
     }
     return null;
   }
@@ -816,6 +840,13 @@ class DatabaseProvider {
     final Database db = await _databaseInstance;
     newARTRefill.createdDate = DateTime.now().toUtc();
     final res = await db.insert(ARTRefill.tableName, newARTRefill.toMap());
+    return res;
+  }
+
+  Future<void> insertSupportOptionDone(SupportOptionDone supportOptionDone, {DateTime createdDate}) async {
+    final Database db = await _databaseInstance;
+    supportOptionDone.createdDate = createdDate ?? DateTime.now().toUtc();
+    final res = await db.insert(SupportOptionDone.tableName, supportOptionDone.toMap());
     return res;
   }
 
@@ -857,6 +888,25 @@ class DatabaseProvider {
     final Set<RequiredAction> set = {};
     for (Map map in res) {
       set.add(RequiredAction.fromMap(map));
+    }
+    return set;
+  }
+
+  /// Retrieves only the support option done statuses for the preference
+  /// assessment with [preferenceAssessmentId]. The elements in the set will
+  /// be the ones with the most recent 'done' status.
+  Future<Set<SupportOptionDone>> retrieveDoneSupportOptionsForPreferenceAssessment(int preferenceAssessmentId) async {
+    final Database db = await _databaseInstance;
+    final List<Map> res = await db.query(
+      SupportOptionDone.tableName,
+      where: '${SupportOptionDone.colPreferenceAssessmentId} = ?',
+      whereArgs: [preferenceAssessmentId],
+      orderBy: '${SupportOptionDone.colCreatedDate} DESC',
+    );
+    final Set<SupportOptionDone> set = {};
+    for (Map map in res) {
+      SupportOptionDone supportOptionDone = SupportOptionDone.fromMap(map);
+      set.add(supportOptionDone);
     }
     return set;
   }
@@ -928,6 +978,21 @@ class DatabaseProvider {
       for (Map<String, dynamic> map in res) {
         UserData u = UserData.fromMap(map);
         list.add(u);
+      }
+    }
+    return list;
+  }
+
+  /// Retrieves all support option done data rows from the database, including
+  /// all edits.
+  Future<List<SupportOptionDone>> retrieveAllSupportOptionDones() async {
+    final Database db = await _databaseInstance;
+    final res = await db.query(SupportOptionDone.tableName);
+    List<SupportOptionDone> list = List<SupportOptionDone>();
+    if (res.isNotEmpty) {
+      for (Map<String, dynamic> map in res) {
+        SupportOptionDone s = SupportOptionDone.fromMap(map);
+        list.add(s);
       }
     }
     return list;

--- a/lib/database/DatabaseProvider.dart
+++ b/lib/database/DatabaseProvider.dart
@@ -743,11 +743,12 @@ class DatabaseProvider {
     return list;
   }
 
-  Future<void> insertPreferenceAssessment(PreferenceAssessment newPreferenceAssessment) async {
+  /// Inserts a [PreferenceAssessment] object into database and return the id
+  /// given by the database.
+  Future<int> insertPreferenceAssessment(PreferenceAssessment newPreferenceAssessment) async {
     final Database db = await _databaseInstance;
     newPreferenceAssessment.createdDate = DateTime.now().toUtc();
-    final res = await db.insert(PreferenceAssessment.tableName, newPreferenceAssessment.toMap());
-    return res;
+    return db.insert(PreferenceAssessment.tableName, newPreferenceAssessment.toMap());
   }
 
   Future<void> insertUserData(UserData userData) async {

--- a/lib/database/beans/SupportOption.dart
+++ b/lib/database/beans/SupportOption.dart
@@ -1,0 +1,173 @@
+
+class SupportOption {
+
+  // Class Variables
+  // ---------------
+
+  // Encoding as defined in the study codebook.
+  // NOTE: These integers are the values that are stored in the database. So if
+  // you change the encoding (the integers) you will have to migrate the entire
+  // database to the new encoding!
+  static const Map<_SupportOption, int> _encoding = {
+    _SupportOption.NURSE_CLINIC: 1,
+    _SupportOption.SATURDAY_CLINIC_CLUB: 2,
+    _SupportOption.COMMUNITY_YOUTH_CLUB: 3,
+    _SupportOption.PHONE_CALL_PE: 4,
+    _SupportOption.HOME_VISIT_PE: 5,
+    _SupportOption.SCHOOL_VISIT_PE: 6,
+    _SupportOption.PITSO_VISIT_PE: 7,
+    _SupportOption.CONDOM_DEMO: 8,
+    _SupportOption.CONTRACEPTIVES_INFO: 9,
+    _SupportOption.VMMC_INFO: 10,
+    _SupportOption.YOUNG_MOTHERS_GROUP: 11,
+    _SupportOption.FEMALE_WORTH_GROUP: 12,
+    _SupportOption.LEGAL_AID_INFO: 13,
+    _SupportOption.NONE: 14,
+  };
+
+  // These are the descriptions that will be displayed in the UI.
+  static const Map<_SupportOption, String> _description = {
+    _SupportOption.NURSE_CLINIC: "By the nurse at the clinic",
+    _SupportOption.SATURDAY_CLINIC_CLUB: "Saturday Clinic Club (SCC)",
+    _SupportOption.COMMUNITY_YOUTH_CLUB: "Community Youth Club (CYC)",
+    _SupportOption.PHONE_CALL_PE: "Phone Call by PE",
+    _SupportOption.HOME_VISIT_PE: "Home-visit by PE",
+    _SupportOption.SCHOOL_VISIT_PE: "School visit and health talk by PE",
+    _SupportOption.PITSO_VISIT_PE: "Pitso visit and health talk by PE",
+    _SupportOption.CONDOM_DEMO: "Condom demonstration",
+    _SupportOption.CONTRACEPTIVES_INFO: "More information about contraceptives",
+    _SupportOption.VMMC_INFO: "More information about VMMC",
+    _SupportOption.YOUNG_MOTHERS_GROUP: "Linkage to young mothers group (DREAMS or Mothers-to-Mothers)",
+    _SupportOption.FEMALE_WORTH_GROUP: "Linkage to a female WORTH group (Social Asset Building Model)",
+    _SupportOption.LEGAL_AID_INFO: "Legal aid information",
+    _SupportOption.NONE: "No support wished",
+  };
+
+  _SupportOption _option;
+
+  // Constructors
+  // ------------
+
+  // make default constructor private
+  SupportOption._();
+
+  SupportOption.NURSE_CLINIC() {
+    _option = _SupportOption.NURSE_CLINIC;
+  }
+
+  SupportOption.SATURDAY_CLINIC_CLUB() {
+    _option = _SupportOption.SATURDAY_CLINIC_CLUB;
+  }
+
+  SupportOption.COMMUNITY_YOUTH_CLUB() {
+    _option = _SupportOption.COMMUNITY_YOUTH_CLUB;
+  }
+
+  SupportOption.PHONE_CALL_PE() {
+    _option = _SupportOption.PHONE_CALL_PE;
+  }
+
+  SupportOption.HOME_VISIT_PE() {
+    _option = _SupportOption.HOME_VISIT_PE;
+  }
+
+  SupportOption.SCHOOL_VISIT_PE() {
+    _option = _SupportOption.SCHOOL_VISIT_PE;
+  }
+
+  SupportOption.PITSO_VISIT_PE() {
+    _option = _SupportOption.PITSO_VISIT_PE;
+  }
+
+  SupportOption.CONDOM_DEMO() {
+    _option = _SupportOption.CONDOM_DEMO;
+  }
+
+  SupportOption.CONTRACEPTIVES_INFO() {
+    _option = _SupportOption.CONTRACEPTIVES_INFO;
+  }
+
+  SupportOption.VMMC_INFO() {
+    _option = _SupportOption.VMMC_INFO;
+  }
+
+  SupportOption.YOUNG_MOTHERS_GROUP() {
+    _option = _SupportOption.YOUNG_MOTHERS_GROUP;
+  }
+
+  SupportOption.FEMALE_WORTH_GROUP() {
+    _option = _SupportOption.FEMALE_WORTH_GROUP;
+  }
+
+  SupportOption.LEGAL_AID_INFO() {
+    _option = _SupportOption.LEGAL_AID_INFO;
+  }
+
+  SupportOption.NONE() {
+    _option = _SupportOption.NONE;
+  }
+
+  static SupportOption fromCode(int code) {
+    if (code == null || !_encoding.containsValue(code)) {
+      return null;
+    }
+    final _SupportOption option = _encoding.entries.firstWhere((MapEntry<_SupportOption, int> entry) {
+      return entry.value == code;
+    }).key;
+    SupportOption object = SupportOption._();
+    object._option = option;
+    return object;
+  }
+
+  // Public API
+  // ----------
+
+  // override the equality operator
+  @override
+  bool operator ==(o) => o is SupportOption && o._option == _option;
+
+  // override hashcode
+  @override
+  int get hashCode => _option.hashCode;
+
+  static List<SupportOption> get allValues => [
+    SupportOption.NURSE_CLINIC(),
+    SupportOption.SATURDAY_CLINIC_CLUB(),
+    SupportOption.COMMUNITY_YOUTH_CLUB(),
+    SupportOption.PHONE_CALL_PE(),
+    SupportOption.HOME_VISIT_PE(),
+    SupportOption.SCHOOL_VISIT_PE(),
+    SupportOption.PITSO_VISIT_PE(),
+    SupportOption.CONDOM_DEMO(),
+    SupportOption.CONTRACEPTIVES_INFO(),
+    SupportOption.VMMC_INFO(),
+    SupportOption.YOUNG_MOTHERS_GROUP(),
+    SupportOption.FEMALE_WORTH_GROUP(),
+    SupportOption.LEGAL_AID_INFO(),
+    SupportOption.NONE(),
+  ];
+
+  /// Returns the text description of this message.
+  String get description => _description[_option];
+
+  /// Returns the code that represents this message.
+  int get code => _encoding[_option];
+
+}
+
+enum _SupportOption {
+  NURSE_CLINIC,
+  SATURDAY_CLINIC_CLUB,
+  COMMUNITY_YOUTH_CLUB,
+  PHONE_CALL_PE,
+  HOME_VISIT_PE,
+  SCHOOL_VISIT_PE,
+  PITSO_VISIT_PE,
+  CONDOM_DEMO,
+  CONTRACEPTIVES_INFO,
+  VMMC_INFO,
+  YOUNG_MOTHERS_GROUP,
+  FEMALE_WORTH_GROUP,
+  LEGAL_AID_INFO,
+  NONE,
+}

--- a/lib/database/beans/SupportPreferencesSelection.dart
+++ b/lib/database/beans/SupportPreferencesSelection.dart
@@ -7,7 +7,7 @@ class SupportPreferencesSelection {
   // Class Variables
   // ---------------
 
-  Set<SupportOption> _selection = { SupportOption.NONE() };
+  Set<SupportOption> _selection = {};
 
 
   // Constructors
@@ -34,8 +34,19 @@ class SupportPreferencesSelection {
     }
   }
 
+  String toExcelString() {
+    String excelString = '';
+    final List<int> selectionAsList = _selection.map((SupportOption option) => option.code).toList();
+    selectionAsList.sort((int a, int b) => a > b ? 1 : -1);
+    if (selectionAsList.isEmpty) {
+      selectionAsList.add(SupportOption.NONE().code);
+    }
+    selectionAsList.forEach((int code) => excelString += '$code, ');
+    return excelString.substring(0, excelString.length - 2);
+  }
+
   String serializeToJSON() {
-    final selectionAsList = _selection.map((SupportOption option) => option.code).toList();
+    final List<int> selectionAsList = _selection.map((SupportOption option) => option.code).toList();
     selectionAsList.sort((int a, int b) => a > b ? 1 : -1);
     return jsonEncode(selectionAsList);
   }
@@ -56,16 +67,9 @@ class SupportPreferencesSelection {
 
   void deselectAll() {
     _selection.clear();
-    _selection.add(SupportOption.NONE());
   }
 
-  bool get areAllDeselected => _selection.length == 1 && _selection.first == SupportOption.NONE();
-
-  /// Returns true if no options are selected that have an icon.
-  bool get areAllWithIconDeselected => (!NURSE_CLINIC_selected
-      && !SATURDAY_CLINIC_CLUB_selected  && !COMMUNITY_YOUTH_CLUB_selected
-      && !PHONE_CALL_PE_selected && !HOME_VISIT_PE_selected
-      && !SCHOOL_VISIT_PE_selected && !PITSO_VISIT_PE_selected);
+  bool get areAllDeselected => _selection.length == 0;
 
   set NURSE_CLINIC_selected(bool selected) {
     selected

--- a/lib/database/beans/SupportPreferencesSelection.dart
+++ b/lib/database/beans/SupportPreferencesSelection.dart
@@ -1,54 +1,19 @@
 import 'dart:convert';
+import 'package:pebrapp/database/beans/SupportOption.dart';
 
 class SupportPreferencesSelection {
 
   // Class Variables
   // ---------------
 
-  // Encoding as defined in the study codebook.
-  // NOTE: These integers are the values that are stored in the database. So if
-  // you change the encoding (the integers) you will have to migrate the entire
-  // database to the new encoding!
-  static const Map<_SupportPreference, int> _encoding = {
-    _SupportPreference.NURSE_CLINIC: 1,
-    _SupportPreference.SATURDAY_CLINIC_CLUB: 2,
-    _SupportPreference.COMMUNITY_YOUTH_CLUB: 3,
-    _SupportPreference.PHONE_CALL_PE: 4,
-    _SupportPreference.HOME_VISIT_PE: 5,
-    _SupportPreference.SCHOOL_VISIT_PE: 6,
-    _SupportPreference.PITSO_VISIT_PE: 7,
-    _SupportPreference.CONDOM_DEMO: 8,
-    _SupportPreference.CONTRACEPTIVES_INFO: 9,
-    _SupportPreference.VMMC_INFO: 10,
-    _SupportPreference.YOUNG_MOTHERS_GROUP: 11,
-    _SupportPreference.FEMALE_WORTH_GROUP: 12,
-    _SupportPreference.LEGAL_AID_INFO: 13,
-  };
-
-  // These are the descriptions that will be displayed in the UI.
-  static String get NURSE_CLINIC_DESCRIPTION => "By the nurse at the clinic";
-  static String get SATURDAY_CLINIC_CLUB_DESCRIPTION => "Saturday Clinic Club (SCC)";
-  static String get COMMUNITY_YOUTH_CLUB_DESCRIPTION => "Community Youth Club (CYC)";
-  static String get PHONE_CALL_PE_DESCRIPTION => "Phone Call by PE";
-  static String get HOME_VISIT_PE_DESCRIPTION => "Home-visit by PE";
-  static String get SCHOOL_VISIT_PE_DESCRIPTION => "School visit and health talk by PE";
-  static String get PITSO_VISIT_PE_DESCRIPTION => "Pitso visit and health talk by PE";
-  static String get CONDOM_DEMO_DESCRIPTION => "Condom demonstration";
-  static String get CONTRACEPTIVES_INFO_DESCRIPTION => "More information about contraceptives";
-  static String get VMMC_INFO_DESCRIPTION => "More information about VMMC";
-  static String get YOUNG_MOTHERS_GROUP_DESCRIPTION => "Linkage to young mothers group (DREAMS or Mothers-to-Mothers)";
-  static String get FEMALE_WORTH_GROUP_DESCRIPTION => "Linkage to a female WORTH group (Social Asset Building Model)";
-  static String get LEGAL_AID_INFO_DESCRIPTION => "Legal aid information";
-  static String get NONE_DESCRIPTION => "No support wished";
-
-  Set<_SupportPreference> _selection = Set();
+  Set<SupportOption> _selection = Set();
 
 
   // Constructors
   // ------------
 
   String serializeToJSON() {
-    final selectionAsList = _selection.map((_SupportPreference pref) => _encoding[pref]).toList();
+    final selectionAsList = _selection.map((SupportOption option) => option.code).toList();
     selectionAsList.sort((int a, int b) => a > b ? 1 : -1);
     return jsonEncode(selectionAsList);
   }
@@ -57,10 +22,8 @@ class SupportPreferencesSelection {
     final list = jsonDecode(json) as List<dynamic>;
     var obj = SupportPreferencesSelection();
     obj._selection = list.map((dynamic code) {
-      final _SupportPreference preference = _encoding.entries.firstWhere((MapEntry<_SupportPreference, int> entry) {
-        return entry.value == code as int;
-      }).key;
-      return preference;
+      final SupportOption option = SupportOption.fromCode(code);
+      return option;
     }).toSet();
     return obj;
   }
@@ -71,9 +34,10 @@ class SupportPreferencesSelection {
 
   void deselectAll() {
     _selection.clear();
+    _selection.add(SupportOption.NONE());
   }
 
-  bool get areAllDeselected => _selection.isEmpty;
+  bool get areAllDeselected => _selection.length == 1 && _selection.first == SupportOption.NONE();
 
   /// Returns true if no options are selected that have an icon.
   bool get areAllWithIconDeselected => (!NURSE_CLINIC_selected
@@ -83,123 +47,107 @@ class SupportPreferencesSelection {
 
   set NURSE_CLINIC_selected(bool selected) {
     selected
-      ? _selection.add(_SupportPreference.NURSE_CLINIC)
-      : _selection.remove(_SupportPreference.NURSE_CLINIC);
+      ? _selection.add(SupportOption.NURSE_CLINIC())
+      : _selection.remove(SupportOption.NURSE_CLINIC());
   }
 
   set SATURDAY_CLINIC_CLUB_selected(bool selected) {
     selected
-        ? _selection.add(_SupportPreference.SATURDAY_CLINIC_CLUB)
-        : _selection.remove(_SupportPreference.SATURDAY_CLINIC_CLUB);
+        ? _selection.add(SupportOption.SATURDAY_CLINIC_CLUB())
+        : _selection.remove(SupportOption.SATURDAY_CLINIC_CLUB());
   }
 
   set COMMUNITY_YOUTH_CLUB_selected(bool selected) {
     selected
-        ? _selection.add(_SupportPreference.COMMUNITY_YOUTH_CLUB)
-        : _selection.remove(_SupportPreference.COMMUNITY_YOUTH_CLUB);
+        ? _selection.add(SupportOption.COMMUNITY_YOUTH_CLUB())
+        : _selection.remove(SupportOption.COMMUNITY_YOUTH_CLUB());
   }
 
   set PHONE_CALL_PE_selected(bool selected) {
     selected
-        ? _selection.add(_SupportPreference.PHONE_CALL_PE)
-        : _selection.remove(_SupportPreference.PHONE_CALL_PE);
+        ? _selection.add(SupportOption.PHONE_CALL_PE())
+        : _selection.remove(SupportOption.PHONE_CALL_PE());
   }
 
   set HOME_VISIT_PE_selected(bool selected) {
     selected
-        ? _selection.add(_SupportPreference.HOME_VISIT_PE)
-        : _selection.remove(_SupportPreference.HOME_VISIT_PE);
+        ? _selection.add(SupportOption.HOME_VISIT_PE())
+        : _selection.remove(SupportOption.HOME_VISIT_PE());
   }
 
   set SCHOOL_VISIT_PE_selected(bool selected) {
     selected
-        ? _selection.add(_SupportPreference.SCHOOL_VISIT_PE)
-        : _selection.remove(_SupportPreference.SCHOOL_VISIT_PE);
+        ? _selection.add(SupportOption.SCHOOL_VISIT_PE())
+        : _selection.remove(SupportOption.SCHOOL_VISIT_PE());
   }
 
   set PITSO_VISIT_PE_selected(bool selected) {
     selected
-        ? _selection.add(_SupportPreference.PITSO_VISIT_PE)
-        : _selection.remove(_SupportPreference.PITSO_VISIT_PE);
+        ? _selection.add(SupportOption.PITSO_VISIT_PE())
+        : _selection.remove(SupportOption.PITSO_VISIT_PE());
   }
 
   set CONDOM_DEMO_selected(bool selected) {
     selected
-        ? _selection.add(_SupportPreference.CONDOM_DEMO)
-        : _selection.remove(_SupportPreference.CONDOM_DEMO);
+        ? _selection.add(SupportOption.CONDOM_DEMO())
+        : _selection.remove(SupportOption.CONDOM_DEMO());
   }
 
   set CONTRACEPTIVES_INFO_selected(bool selected) {
     selected
-        ? _selection.add(_SupportPreference.CONTRACEPTIVES_INFO)
-        : _selection.remove(_SupportPreference.CONTRACEPTIVES_INFO);
+        ? _selection.add(SupportOption.CONTRACEPTIVES_INFO())
+        : _selection.remove(SupportOption.CONTRACEPTIVES_INFO());
   }
 
   set VMMC_INFO_selected(bool selected) {
     selected
-        ? _selection.add(_SupportPreference.VMMC_INFO)
-        : _selection.remove(_SupportPreference.VMMC_INFO);
+        ? _selection.add(SupportOption.VMMC_INFO())
+        : _selection.remove(SupportOption.VMMC_INFO());
   }
 
   set YOUNG_MOTHERS_GROUP_selected(bool selected) {
     selected
-        ? _selection.add(_SupportPreference.YOUNG_MOTHERS_GROUP)
-        : _selection.remove(_SupportPreference.YOUNG_MOTHERS_GROUP);
+        ? _selection.add(SupportOption.YOUNG_MOTHERS_GROUP())
+        : _selection.remove(SupportOption.YOUNG_MOTHERS_GROUP());
   }
 
   set FEMALE_WORTH_GROUP_selected(bool selected) {
     selected
-        ? _selection.add(_SupportPreference.FEMALE_WORTH_GROUP)
-        : _selection.remove(_SupportPreference.FEMALE_WORTH_GROUP);
+        ? _selection.add(SupportOption.FEMALE_WORTH_GROUP())
+        : _selection.remove(SupportOption.FEMALE_WORTH_GROUP());
   }
 
   set LEGAL_AID_INFO_selected(bool selected) {
     selected
-        ? _selection.add(_SupportPreference.LEGAL_AID_INFO)
-        : _selection.remove(_SupportPreference.LEGAL_AID_INFO);
+        ? _selection.add(SupportOption.LEGAL_AID_INFO())
+        : _selection.remove(SupportOption.LEGAL_AID_INFO());
   }
 
 
-  bool get NURSE_CLINIC_selected => _selection.contains(_SupportPreference.NURSE_CLINIC);
+  bool get NURSE_CLINIC_selected => _selection.contains(SupportOption.NURSE_CLINIC());
 
-  bool get SATURDAY_CLINIC_CLUB_selected => _selection.contains(_SupportPreference.SATURDAY_CLINIC_CLUB);
+  bool get SATURDAY_CLINIC_CLUB_selected => _selection.contains(SupportOption.SATURDAY_CLINIC_CLUB());
 
-  bool get COMMUNITY_YOUTH_CLUB_selected => _selection.contains(_SupportPreference.COMMUNITY_YOUTH_CLUB);
+  bool get COMMUNITY_YOUTH_CLUB_selected => _selection.contains(SupportOption.COMMUNITY_YOUTH_CLUB());
 
-  bool get PHONE_CALL_PE_selected => _selection.contains(_SupportPreference.PHONE_CALL_PE);
+  bool get PHONE_CALL_PE_selected => _selection.contains(SupportOption.PHONE_CALL_PE());
 
-  bool get HOME_VISIT_PE_selected => _selection.contains(_SupportPreference.HOME_VISIT_PE);
+  bool get HOME_VISIT_PE_selected => _selection.contains(SupportOption.HOME_VISIT_PE());
 
-  bool get SCHOOL_VISIT_PE_selected => _selection.contains(_SupportPreference.SCHOOL_VISIT_PE);
+  bool get SCHOOL_VISIT_PE_selected => _selection.contains(SupportOption.SCHOOL_VISIT_PE());
 
-  bool get PITSO_VISIT_PE_selected => _selection.contains(_SupportPreference.PITSO_VISIT_PE);
+  bool get PITSO_VISIT_PE_selected => _selection.contains(SupportOption.PITSO_VISIT_PE());
 
-  bool get CONDOM_DEMO_selected => _selection.contains(_SupportPreference.CONDOM_DEMO);
+  bool get CONDOM_DEMO_selected => _selection.contains(SupportOption.CONDOM_DEMO());
 
-  bool get CONTRACEPTIVES_INFO_selected => _selection.contains(_SupportPreference.CONTRACEPTIVES_INFO);
+  bool get CONTRACEPTIVES_INFO_selected => _selection.contains(SupportOption.CONTRACEPTIVES_INFO());
 
-  bool get VMMC_INFO_selected => _selection.contains(_SupportPreference.VMMC_INFO);
+  bool get VMMC_INFO_selected => _selection.contains(SupportOption.VMMC_INFO());
 
-  bool get YOUNG_MOTHERS_GROUP_selected => _selection.contains(_SupportPreference.YOUNG_MOTHERS_GROUP);
+  bool get YOUNG_MOTHERS_GROUP_selected => _selection.contains(SupportOption.YOUNG_MOTHERS_GROUP());
 
-  bool get FEMALE_WORTH_GROUP_selected => _selection.contains(_SupportPreference.FEMALE_WORTH_GROUP);
+  bool get FEMALE_WORTH_GROUP_selected => _selection.contains(SupportOption.FEMALE_WORTH_GROUP());
 
-  bool get LEGAL_AID_INFO_selected => _selection.contains(_SupportPreference.LEGAL_AID_INFO);
+  bool get LEGAL_AID_INFO_selected => _selection.contains(SupportOption.LEGAL_AID_INFO());
 
-}
-
-enum _SupportPreference {
-  NURSE_CLINIC,
-  SATURDAY_CLINIC_CLUB,
-  COMMUNITY_YOUTH_CLUB,
-  PHONE_CALL_PE,
-  HOME_VISIT_PE,
-  SCHOOL_VISIT_PE,
-  PITSO_VISIT_PE,
-  CONDOM_DEMO,
-  CONTRACEPTIVES_INFO,
-  VMMC_INFO,
-  YOUNG_MOTHERS_GROUP,
-  FEMALE_WORTH_GROUP,
-  LEGAL_AID_INFO,
 }

--- a/lib/database/beans/SupportPreferencesSelection.dart
+++ b/lib/database/beans/SupportPreferencesSelection.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:pebrapp/database/beans/SupportOption.dart';
+import 'package:pebrapp/database/models/PreferenceAssessment.dart';
 
 class SupportPreferencesSelection {
 
@@ -11,6 +12,27 @@ class SupportPreferencesSelection {
 
   // Constructors
   // ------------
+
+  SupportPreferencesSelection();
+
+  SupportPreferencesSelection.fromLastAssessment(PreferenceAssessment pa) {
+    if (pa != null) {
+      final SupportPreferencesSelection lastSelection = pa.supportPreferences;
+      NURSE_CLINIC_selected = lastSelection.NURSE_CLINIC_selected && !pa.NURSE_CLINIC_done;
+      SATURDAY_CLINIC_CLUB_selected = lastSelection.SATURDAY_CLINIC_CLUB_selected && pa.saturdayClinicClubAvailable && !pa.SATURDAY_CLINIC_CLUB_done;
+      COMMUNITY_YOUTH_CLUB_selected = lastSelection.COMMUNITY_YOUTH_CLUB_selected && pa.communityYouthClubAvailable && !pa.COMMUNITY_YOUTH_CLUB_done;
+      PHONE_CALL_PE_selected = lastSelection.PHONE_CALL_PE_selected && !pa.PHONE_CALL_PE_done;
+      HOME_VISIT_PE_selected = lastSelection.HOME_VISIT_PE_selected && pa.homeVisitPEPossible && !pa.HOME_VISIT_PE_done;
+      SCHOOL_VISIT_PE_selected = lastSelection.SCHOOL_VISIT_PE_selected && pa.schoolVisitPEPossible && !pa.SCHOOL_VISIT_PE_done;
+      PITSO_VISIT_PE_selected = lastSelection.PITSO_VISIT_PE_selected && pa.pitsoPEPossible && !pa.PITSO_VISIT_PE_done;
+      CONDOM_DEMO_selected = lastSelection.CONDOM_DEMO_selected && !pa.CONDOM_DEMO_done;
+      CONTRACEPTIVES_INFO_selected = lastSelection.CONTRACEPTIVES_INFO_selected && !pa.CONTRACEPTIVES_INFO_done;
+      VMMC_INFO_selected = lastSelection.VMMC_INFO_selected && !pa.VMMC_INFO_done;
+      YOUNG_MOTHERS_GROUP_selected = lastSelection.YOUNG_MOTHERS_GROUP_selected && pa.youngMothersAvailable && !pa.YOUNG_MOTHERS_GROUP_done;
+      FEMALE_WORTH_GROUP_selected = lastSelection.FEMALE_WORTH_GROUP_selected && pa.femaleWorthAvailable && !pa.FEMALE_WORTH_GROUP_done;
+      LEGAL_AID_INFO_selected = lastSelection.LEGAL_AID_INFO_selected && pa.legalAidSmartphoneAvailable && !pa.LEGAL_AID_INFO_done;
+    }
+  }
 
   String serializeToJSON() {
     final selectionAsList = _selection.map((SupportOption option) => option.code).toList();

--- a/lib/database/beans/SupportPreferencesSelection.dart
+++ b/lib/database/beans/SupportPreferencesSelection.dart
@@ -7,7 +7,7 @@ class SupportPreferencesSelection {
   // Class Variables
   // ---------------
 
-  Set<SupportOption> _selection = Set();
+  Set<SupportOption> _selection = { SupportOption.NONE() };
 
 
   // Constructors

--- a/lib/database/beans/SupportPreferencesSelection.dart
+++ b/lib/database/beans/SupportPreferencesSelection.dart
@@ -75,14 +75,8 @@ class SupportPreferencesSelection {
 
   bool get areAllDeselected => _selection.isEmpty;
 
-  /// Returns true if no options are selected that require an action from the
-  /// peer educator.
-  ///
-  /// E.g., the option 'Phone Call PE' requires the peer educator to make a call
-  /// and then tick off the option in the patient screen.
-  ///
-  /// These are also the support options which have an icon.
-  bool get areAllWithTodoDeselected => (!NURSE_CLINIC_selected
+  /// Returns true if no options are selected that have an icon.
+  bool get areAllWithIconDeselected => (!NURSE_CLINIC_selected
       && !SATURDAY_CLINIC_CLUB_selected  && !COMMUNITY_YOUTH_CLUB_selected
       && !PHONE_CALL_PE_selected && !HOME_VISIT_PE_selected
       && !SCHOOL_VISIT_PE_selected && !PITSO_VISIT_PE_selected);

--- a/lib/database/models/Patient.dart
+++ b/lib/database/models/Patient.dart
@@ -52,10 +52,9 @@ class Patient implements IExcelExportable {
   NoConsentReason noConsentReason;
   String noConsentReasonOther;
   bool isActivated;
-  // The following are not columns in the database, just the objects for easier
-  // access to the latest PreferenceAssessment/ARTRefill.
-  // Will be null until the [initializePreferenceAssessmentField]/
-  // [initializeARTRefillField] method was called.
+  // The following fields are other database tables, to make access to related
+  // database objects easier.
+  // Will be null until the corresponding initialize... methods were called.
   List<ViralLoad> viralLoads = [];
   PreferenceAssessment latestPreferenceAssessment;
   ARTRefill latestARTRefill; // stores the latest ART refill (done or not done)

--- a/lib/database/models/PreferenceAssessment.dart
+++ b/lib/database/models/PreferenceAssessment.dart
@@ -446,6 +446,20 @@ class PreferenceAssessment implements IExcelExportable {
 
   ARTRefillOption get lastRefillOption => artRefillOption5 ?? artRefillOption4 ?? artRefillOption3 ?? artRefillOption2 ?? artRefillOption1;
 
+  DateTime get NURSE_CLINIC_done_date => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.NURSE_CLINIC() && s.done, orElse: () => null)?.createdDate;
+  DateTime get SATURDAY_CLINIC_CLUB_done_date => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.SATURDAY_CLINIC_CLUB() && s.done, orElse: () => null)?.createdDate;
+  DateTime get COMMUNITY_YOUTH_CLUB_done_date => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.COMMUNITY_YOUTH_CLUB() && s.done, orElse: () => null)?.createdDate;
+  DateTime get PHONE_CALL_PE_done_date => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.PHONE_CALL_PE() && s.done, orElse: () => null)?.createdDate;
+  DateTime get HOME_VISIT_PE_done_date => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.HOME_VISIT_PE() && s.done, orElse: () => null)?.createdDate;
+  DateTime get SCHOOL_VISIT_PE_done_date => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.SCHOOL_VISIT_PE() && s.done, orElse: () => null)?.createdDate;
+  DateTime get PITSO_VISIT_PE_done_date => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.PITSO_VISIT_PE() && s.done, orElse: () => null)?.createdDate;
+  DateTime get CONDOM_DEMO_done_date =>_supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.CONDOM_DEMO() && s.done, orElse: () => null)?.createdDate;
+  DateTime get CONTRACEPTIVES_INFO_done_date => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.CONTRACEPTIVES_INFO() && s.done, orElse: () => null)?.createdDate;
+  DateTime get VMMC_INFO_done_date => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.VMMC_INFO() && s.done, orElse: () => null)?.createdDate;
+  DateTime get YOUNG_MOTHERS_GROUP_done_date => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.YOUNG_MOTHERS_GROUP() && s.done, orElse: () => null)?.createdDate;
+  DateTime get FEMALE_WORTH_GROUP_done_date => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.FEMALE_WORTH_GROUP() && s.done, orElse: () => null)?.createdDate;
+  DateTime get LEGAL_AID_INFO_done_date => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.LEGAL_AID_INFO() && s.done, orElse: () => null)?.createdDate;
+
   bool get NURSE_CLINIC_done => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.NURSE_CLINIC() && s.done, orElse: () => null) != null;
   bool get SATURDAY_CLINIC_CLUB_done => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.SATURDAY_CLINIC_CLUB() && s.done, orElse: () => null) != null;
   bool get COMMUNITY_YOUTH_CLUB_done => _supportOptionDones.firstWhere((SupportOptionDone s) => s.supportOption == SupportOption.COMMUNITY_YOUTH_CLUB() && s.done, orElse: () => null) != null;

--- a/lib/database/models/SupportOptionDone.dart
+++ b/lib/database/models/SupportOptionDone.dart
@@ -1,0 +1,96 @@
+
+import 'package:pebrapp/config/PEBRAConfig.dart';
+import 'package:pebrapp/database/DatabaseExporter.dart';
+import 'package:pebrapp/database/beans/SupportOption.dart';
+import 'package:pebrapp/database/beans/ViralLoadSource.dart';
+import 'package:pebrapp/utils/Utils.dart';
+
+class SupportOptionDone implements IExcelExportable {
+  static final tableName = 'SupportOptionDone';
+
+  // column names
+  static final colId = 'id'; // primary key
+  static final colCreatedDate = 'created_date';
+  static final colPreferenceAssessmentId = 'preference_assessment_id'; // foreign key to [PreferenceAssessment].id
+  static final colSupportOption = 'support_option';
+  static final colDone = 'done';
+
+  DateTime _createdDate;
+  int preferenceAssessmentId;
+  SupportOption supportOption;
+  bool done;
+
+  // Constructors
+  // ------------
+
+  SupportOptionDone({this.preferenceAssessmentId, this.supportOption, this.done});
+
+  SupportOptionDone.fromMap(map) {
+    this._createdDate = DateTime.parse(map[colCreatedDate]);
+    this.preferenceAssessmentId = map[colPreferenceAssessmentId];
+    this.supportOption = SupportOption.fromCode(map[colSupportOption]);
+    this.done = map[colDone] == 1;
+  }
+
+
+  // Other
+  // -----
+
+  // override the equality operator
+  @override
+  bool operator ==(o) => o is SupportOptionDone
+      && o.preferenceAssessmentId == preferenceAssessmentId
+      && o.supportOption == supportOption;
+
+  // override hashcode
+  @override
+  int get hashCode => preferenceAssessmentId.hashCode^supportOption.hashCode;
+
+  toMap() {
+    var map = Map<String, dynamic>();
+    map[colCreatedDate] = _createdDate.toIso8601String();
+    map[colPreferenceAssessmentId] = preferenceAssessmentId;
+    map[colSupportOption] = supportOption.code;
+    map[colDone] = done;
+    return map;
+  }
+
+  static const int _numberOfColumns = 5;
+
+  /// Column names for the header row in the excel sheet.
+  // If we change the order here, make sure to change the order in the
+  // [toExcelRow] method as well!
+  static List<String> get excelHeaderRow {
+    List<String> row = List<String>(_numberOfColumns);
+    row[0] = 'DATE_CREATED';
+    row[1] = 'TIME_CREATED';
+    row[2] = 'PA_ID';
+    row[3] = 'SUPPORT';
+    row[4] = 'DONE';
+    return row;
+  }
+
+  /// Turns this object into a row that can be written to the excel sheet.
+  // If we change the order here, make sure to change the order in the
+  // [excelHeaderRow] method as well!
+  @override
+  List<dynamic> toExcelRow() {
+    List<dynamic> row = List<dynamic>(_numberOfColumns);
+    row[0] = formatDateIso(_createdDate);
+    row[1] = formatTimeIso(_createdDate);
+    row[2] = preferenceAssessmentId;
+    row[3] = supportOption.code;
+    row[4] = done;
+    return row;
+  }
+
+
+  /// Do not set the createdDate manually! The DatabaseProvider sets the date
+  /// automatically on inserts into database.
+  // ignore: unnecessary_getters_setters
+  set createdDate(DateTime date) => _createdDate = date;
+
+  // ignore: unnecessary_getters_setters
+  DateTime get createdDate => _createdDate;
+
+}

--- a/lib/screens/IconExplanationsScreen.dart
+++ b/lib/screens/IconExplanationsScreen.dart
@@ -2,7 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:pebrapp/components/PopupScreen.dart';
 import 'package:pebrapp/config/PEBRAConfig.dart';
-import 'package:pebrapp/database/beans/SupportPreferencesSelection.dart';
+import 'package:pebrapp/database/beans/SupportOption.dart';
 
 class IconExplanationsScreen extends StatefulWidget {
   @override
@@ -18,13 +18,13 @@ class _IconExplanationsScreenState extends State<IconExplanationsScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          _makeExplanation('assets/icons/nurse_clinic.png', SupportPreferencesSelection.NURSE_CLINIC_DESCRIPTION),
-          _makeExplanation('assets/icons/saturday_clinic_club.png', SupportPreferencesSelection.SATURDAY_CLINIC_CLUB_DESCRIPTION),
-          _makeExplanation('assets/icons/youth_club.png', SupportPreferencesSelection.COMMUNITY_YOUTH_CLUB_DESCRIPTION),
-          _makeExplanation('assets/icons/phonecall_pe.png', SupportPreferencesSelection.PHONE_CALL_PE_DESCRIPTION),
-          _makeExplanation('assets/icons/homevisit_pe.png', SupportPreferencesSelection.HOME_VISIT_PE_DESCRIPTION),
-          _makeExplanation('assets/icons/schooltalk_pe.png', SupportPreferencesSelection.SCHOOL_VISIT_PE_DESCRIPTION),
-          _makeExplanation('assets/icons/pitso.png', SupportPreferencesSelection.PITSO_VISIT_PE_DESCRIPTION),
+          _makeExplanation('assets/icons/nurse_clinic.png', SupportOption.NURSE_CLINIC().description),
+          _makeExplanation('assets/icons/saturday_clinic_club.png', SupportOption.SATURDAY_CLINIC_CLUB().description),
+          _makeExplanation('assets/icons/youth_club.png', SupportOption.COMMUNITY_YOUTH_CLUB().description),
+          _makeExplanation('assets/icons/phonecall_pe.png', SupportOption.PHONE_CALL_PE().description),
+          _makeExplanation('assets/icons/homevisit_pe.png', SupportOption.HOME_VISIT_PE().description),
+          _makeExplanation('assets/icons/schooltalk_pe.png', SupportOption.SCHOOL_VISIT_PE().description),
+          _makeExplanation('assets/icons/pitso.png', SupportOption.PITSO_VISIT_PE().description),
           _makeExplanation('assets/icons/viralload_suppressed.png', 'Suppressed (viral load < $VL_SUPPRESSED_THRESHOLD copies/mL)'),
           _makeExplanation('assets/icons/viralload_unsuppressed.png', 'Unsuppressed (viral load missing or ≥ $VL_SUPPRESSED_THRESHOLD copies/mL)'),
           SizedBox(height: 30),

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -537,34 +537,34 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
       Color iconColor = isActivated ? ICON_ACTIVE : ICON_INACTIVE;
       final Container spacer = Container(width: 3);
       if (sps.NURSE_CLINIC_selected) {
-        icons.add(_getPaddedIcon('assets/icons/nurse_clinic.png', color: iconColor));
+        icons.add(_getPaddedIcon('assets/icons/nurse_clinic.png', color: pa.NURSE_CLINIC_done ? ICON_INACTIVE : iconColor));
         icons.add(spacer);
       }
       if (sps.SATURDAY_CLINIC_CLUB_selected && pa.saturdayClinicClubAvailable) {
-        icons.add(_getPaddedIcon('assets/icons/saturday_clinic_club.png', color: iconColor));
+        icons.add(_getPaddedIcon('assets/icons/saturday_clinic_club.png', color: pa.SATURDAY_CLINIC_CLUB_done ? ICON_INACTIVE : iconColor));
         icons.add(spacer);
       }
       if (sps.COMMUNITY_YOUTH_CLUB_selected && pa.communityYouthClubAvailable) {
-        icons.add(_getPaddedIcon('assets/icons/youth_club.png', color: iconColor));
+        icons.add(_getPaddedIcon('assets/icons/youth_club.png', color: pa.COMMUNITY_YOUTH_CLUB_done ? ICON_INACTIVE : iconColor));
         icons.add(spacer);
       }
       if (sps.PHONE_CALL_PE_selected) {
 //        icons.add(Icon(Icons.phone));
-        icons.add(_getPaddedIcon('assets/icons/phonecall_pe.png', color: iconColor));
+        icons.add(_getPaddedIcon('assets/icons/phonecall_pe.png', color: pa.PHONE_CALL_PE_done ? ICON_INACTIVE : iconColor));
         icons.add(spacer);
       }
       if (sps.HOME_VISIT_PE_selected && pa.homeVisitPEPossible) {
 //        icons.add(Icon(Icons.home));
-        icons.add(_getPaddedIcon('assets/icons/homevisit_pe.png', color: iconColor));
+        icons.add(_getPaddedIcon('assets/icons/homevisit_pe.png', color: pa.HOME_VISIT_PE_done ? ICON_INACTIVE : iconColor));
         icons.add(spacer);
       }
       if (sps.SCHOOL_VISIT_PE_selected && pa.schoolVisitPEPossible) {
 //        icons.add(Icon(Icons.school));
-        icons.add(_getPaddedIcon('assets/icons/schooltalk_pe.png', color: iconColor));
+        icons.add(_getPaddedIcon('assets/icons/schooltalk_pe.png', color: pa.SCHOOL_VISIT_PE_done ? ICON_INACTIVE : iconColor));
         icons.add(spacer);
       }
       if (sps.PITSO_VISIT_PE_selected && pa.pitsoPEPossible) {
-        icons.add(_getPaddedIcon('assets/icons/pitso.png', color: iconColor));
+        icons.add(_getPaddedIcon('assets/icons/pitso.png', color: pa.PITSO_VISIT_PE_done ? ICON_INACTIVE : iconColor));
         icons.add(spacer);
       }
       if (sps.areAllDeselected) {

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -12,6 +12,7 @@ import 'package:pebrapp/config/PEBRAConfig.dart';
 import 'package:pebrapp/database/DatabaseProvider.dart';
 import 'package:pebrapp/database/beans/ARTRefillOption.dart';
 import 'package:pebrapp/database/beans/SupportPreferencesSelection.dart';
+import 'package:pebrapp/database/models/PreferenceAssessment.dart';
 import 'package:pebrapp/database/models/RequiredAction.dart';
 import 'package:pebrapp/database/models/UserData.dart';
 import 'package:pebrapp/exceptions/DocumentNotFoundException.dart';
@@ -527,22 +528,23 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
               )));
     }
 
-    Widget _buildSupportIcons(SupportPreferencesSelection sps, {bool isActivated: true}) {
+    Widget _buildSupportIcons(PreferenceAssessment pa, {bool isActivated: true}) {
+      if (pa == null) {
+        return _formatPatientRowText('—', isActivated: isActivated);
+      }
+      final SupportPreferencesSelection sps = pa.supportPreferences;
       List<Widget> icons = List<Widget>();
       Color iconColor = isActivated ? ICON_ACTIVE : ICON_INACTIVE;
       final Container spacer = Container(width: 3);
-      if (sps == null) {
-        return _formatPatientRowText('—', isActivated: isActivated);
-      }
       if (sps.NURSE_CLINIC_selected) {
         icons.add(_getPaddedIcon('assets/icons/nurse_clinic.png', color: iconColor));
         icons.add(spacer);
       }
-      if (sps.SATURDAY_CLINIC_CLUB_selected) {
+      if (sps.SATURDAY_CLINIC_CLUB_selected && pa.saturdayClinicClubAvailable) {
         icons.add(_getPaddedIcon('assets/icons/saturday_clinic_club.png', color: iconColor));
         icons.add(spacer);
       }
-      if (sps.COMMUNITY_YOUTH_CLUB_selected) {
+      if (sps.COMMUNITY_YOUTH_CLUB_selected && pa.communityYouthClubAvailable) {
         icons.add(_getPaddedIcon('assets/icons/youth_club.png', color: iconColor));
         icons.add(spacer);
       }
@@ -551,25 +553,25 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
         icons.add(_getPaddedIcon('assets/icons/phonecall_pe.png', color: iconColor));
         icons.add(spacer);
       }
-      if (sps.HOME_VISIT_PE_selected) {
+      if (sps.HOME_VISIT_PE_selected && pa.homeVisitPEPossible) {
 //        icons.add(Icon(Icons.home));
         icons.add(_getPaddedIcon('assets/icons/homevisit_pe.png', color: iconColor));
         icons.add(spacer);
       }
-      if (sps.SCHOOL_VISIT_PE_selected) {
+      if (sps.SCHOOL_VISIT_PE_selected && pa.schoolVisitPEPossible) {
 //        icons.add(Icon(Icons.school));
         icons.add(_getPaddedIcon('assets/icons/schooltalk_pe.png', color: iconColor));
         icons.add(spacer);
       }
-      if (sps.PITSO_VISIT_PE_selected) {
+      if (sps.PITSO_VISIT_PE_selected && pa.pitsoPEPossible) {
         icons.add(_getPaddedIcon('assets/icons/pitso.png', color: iconColor));
         icons.add(spacer);
       }
       if (sps.areAllDeselected) {
         icons.add(_getPaddedIcon('assets/icons/no_support.png', color: iconColor));
         icons.add(spacer);
-      } else if (sps.areAllWithTodoDeselected) {
-        return _formatPatientRowText('—', isActivated: isActivated);
+      } else if (sps.areAllWithIconDeselected) {
+        return _formatPatientRowText('…', isActivated: isActivated);
       }
       if (icons.length > 0 && icons.last == spacer) {
         // remove last spacer as there are no more icons that follow it
@@ -766,7 +768,7 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
                       // Support
                       Container(
                         width: _supportWidth,
-                        child: _buildSupportIcons(curPatient?.latestPreferenceAssessment?.supportPreferences, isActivated: curPatient.isActivated),
+                        child: _buildSupportIcons(curPatient?.latestPreferenceAssessment, isActivated: curPatient.isActivated),
                       ),
                       // Viral Load
                       Container(

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -570,7 +570,8 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
       if (sps.areAllDeselected) {
         icons.add(_getPaddedIcon('assets/icons/no_support.png', color: iconColor));
         icons.add(spacer);
-      } else if (sps.areAllWithIconDeselected) {
+      } if (icons.isEmpty) {
+        // indicate with '…' that options were selected which do not have an icon
         return _formatPatientRowText('…', isActivated: isActivated);
       }
       if (icons.length > 0 && icons.last == spacer) {

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -537,35 +537,32 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
       Color iconColor = isActivated ? ICON_ACTIVE : ICON_INACTIVE;
       final Container spacer = Container(width: 3);
       if (sps.NURSE_CLINIC_selected) {
-        icons.add(_getPaddedIcon('assets/icons/nurse_clinic.png', color: pa.NURSE_CLINIC_done ? ICON_INACTIVE : iconColor));
-        icons.add(spacer);
+        final icon = [_getPaddedIcon('assets/icons/nurse_clinic.png', color: pa.NURSE_CLINIC_done ? ICON_INACTIVE : iconColor), spacer];
+        pa.NURSE_CLINIC_done ? icons.addAll(icon) : icons.insertAll(0, icon);
       }
       if (sps.SATURDAY_CLINIC_CLUB_selected && pa.saturdayClinicClubAvailable) {
-        icons.add(_getPaddedIcon('assets/icons/saturday_clinic_club.png', color: pa.SATURDAY_CLINIC_CLUB_done ? ICON_INACTIVE : iconColor));
-        icons.add(spacer);
+        final icon = [_getPaddedIcon('assets/icons/saturday_clinic_club.png', color: pa.SATURDAY_CLINIC_CLUB_done ? ICON_INACTIVE : iconColor), spacer];
+        pa.SATURDAY_CLINIC_CLUB_done ? icons.addAll(icon) : icons.insertAll(0, icon);
       }
       if (sps.COMMUNITY_YOUTH_CLUB_selected && pa.communityYouthClubAvailable) {
-        icons.add(_getPaddedIcon('assets/icons/youth_club.png', color: pa.COMMUNITY_YOUTH_CLUB_done ? ICON_INACTIVE : iconColor));
-        icons.add(spacer);
+        final icon = [_getPaddedIcon('assets/icons/youth_club.png', color: pa.COMMUNITY_YOUTH_CLUB_done ? ICON_INACTIVE : iconColor), spacer];
+        pa.COMMUNITY_YOUTH_CLUB_done ? icons.addAll(icon) : icons.insertAll(0, icon);
       }
       if (sps.PHONE_CALL_PE_selected) {
-//        icons.add(Icon(Icons.phone));
-        icons.add(_getPaddedIcon('assets/icons/phonecall_pe.png', color: pa.PHONE_CALL_PE_done ? ICON_INACTIVE : iconColor));
-        icons.add(spacer);
+        final icon = [_getPaddedIcon('assets/icons/phonecall_pe.png', color: pa.PHONE_CALL_PE_done ? ICON_INACTIVE : iconColor), spacer];
+        pa.PHONE_CALL_PE_done ? icons.addAll(icon) : icons.insertAll(0, icon);
       }
       if (sps.HOME_VISIT_PE_selected && pa.homeVisitPEPossible) {
-//        icons.add(Icon(Icons.home));
-        icons.add(_getPaddedIcon('assets/icons/homevisit_pe.png', color: pa.HOME_VISIT_PE_done ? ICON_INACTIVE : iconColor));
-        icons.add(spacer);
+        final icon = [_getPaddedIcon('assets/icons/homevisit_pe.png', color: pa.HOME_VISIT_PE_done ? ICON_INACTIVE : iconColor), spacer];
+        pa.HOME_VISIT_PE_done ? icons.addAll(icon) : icons.insertAll(0, icon);
       }
       if (sps.SCHOOL_VISIT_PE_selected && pa.schoolVisitPEPossible) {
-//        icons.add(Icon(Icons.school));
-        icons.add(_getPaddedIcon('assets/icons/schooltalk_pe.png', color: pa.SCHOOL_VISIT_PE_done ? ICON_INACTIVE : iconColor));
-        icons.add(spacer);
+        final icon = [_getPaddedIcon('assets/icons/schooltalk_pe.png', color: pa.SCHOOL_VISIT_PE_done ? ICON_INACTIVE : iconColor), spacer];
+        pa.SCHOOL_VISIT_PE_done ? icons.addAll(icon) : icons.insertAll(0, icon);
       }
       if (sps.PITSO_VISIT_PE_selected && pa.pitsoPEPossible) {
-        icons.add(_getPaddedIcon('assets/icons/pitso.png', color: pa.PITSO_VISIT_PE_done ? ICON_INACTIVE : iconColor));
-        icons.add(spacer);
+        final icon = [_getPaddedIcon('assets/icons/pitso.png', color: pa.PITSO_VISIT_PE_done ? ICON_INACTIVE : iconColor), spacer];
+        pa.PITSO_VISIT_PE_done ? icons.addAll(icon) : icons.insertAll(0, icon);
       }
       if (sps.areAllDeselected) {
         icons.add(_getPaddedIcon('assets/icons/no_support.png', color: iconColor));

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -528,44 +528,48 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
               )));
     }
 
+    ClipRect _getPaddedSupportIcon(String assetLocation, {bool active: true}) {
+      final Color iconColor = active ? ICON_ACTIVE : ICON_INACTIVE;
+      return _getPaddedIcon(assetLocation, color: iconColor);
+    }
+
     Widget _buildSupportIcons(PreferenceAssessment pa, {bool isActivated: true}) {
       if (pa == null) {
         return _formatPatientRowText('—', isActivated: isActivated);
       }
       final SupportPreferencesSelection sps = pa.supportPreferences;
       List<Widget> icons = List<Widget>();
-      Color iconColor = isActivated ? ICON_ACTIVE : ICON_INACTIVE;
       final Container spacer = Container(width: 3);
       if (sps.NURSE_CLINIC_selected) {
-        final icon = [_getPaddedIcon('assets/icons/nurse_clinic.png', color: pa.NURSE_CLINIC_done ? ICON_INACTIVE : iconColor), spacer];
+        final icon = [_getPaddedSupportIcon('assets/icons/nurse_clinic.png', active: isActivated && !pa.NURSE_CLINIC_done), spacer];
         pa.NURSE_CLINIC_done ? icons.addAll(icon) : icons.insertAll(0, icon);
       }
       if (sps.SATURDAY_CLINIC_CLUB_selected && pa.saturdayClinicClubAvailable) {
-        final icon = [_getPaddedIcon('assets/icons/saturday_clinic_club.png', color: pa.SATURDAY_CLINIC_CLUB_done ? ICON_INACTIVE : iconColor), spacer];
+        final icon = [_getPaddedSupportIcon('assets/icons/saturday_clinic_club.png', active: isActivated && !pa.SATURDAY_CLINIC_CLUB_done), spacer];
         pa.SATURDAY_CLINIC_CLUB_done ? icons.addAll(icon) : icons.insertAll(0, icon);
       }
       if (sps.COMMUNITY_YOUTH_CLUB_selected && pa.communityYouthClubAvailable) {
-        final icon = [_getPaddedIcon('assets/icons/youth_club.png', color: pa.COMMUNITY_YOUTH_CLUB_done ? ICON_INACTIVE : iconColor), spacer];
+        final icon = [_getPaddedSupportIcon('assets/icons/youth_club.png', active: isActivated && !pa.COMMUNITY_YOUTH_CLUB_done), spacer];
         pa.COMMUNITY_YOUTH_CLUB_done ? icons.addAll(icon) : icons.insertAll(0, icon);
       }
       if (sps.PHONE_CALL_PE_selected) {
-        final icon = [_getPaddedIcon('assets/icons/phonecall_pe.png', color: pa.PHONE_CALL_PE_done ? ICON_INACTIVE : iconColor), spacer];
+        final icon = [_getPaddedSupportIcon('assets/icons/phonecall_pe.png', active: isActivated && !pa.PHONE_CALL_PE_done), spacer];
         pa.PHONE_CALL_PE_done ? icons.addAll(icon) : icons.insertAll(0, icon);
       }
       if (sps.HOME_VISIT_PE_selected && pa.homeVisitPEPossible) {
-        final icon = [_getPaddedIcon('assets/icons/homevisit_pe.png', color: pa.HOME_VISIT_PE_done ? ICON_INACTIVE : iconColor), spacer];
+        final icon = [_getPaddedSupportIcon('assets/icons/homevisit_pe.png', active: isActivated && !pa.HOME_VISIT_PE_done), spacer];
         pa.HOME_VISIT_PE_done ? icons.addAll(icon) : icons.insertAll(0, icon);
       }
       if (sps.SCHOOL_VISIT_PE_selected && pa.schoolVisitPEPossible) {
-        final icon = [_getPaddedIcon('assets/icons/schooltalk_pe.png', color: pa.SCHOOL_VISIT_PE_done ? ICON_INACTIVE : iconColor), spacer];
+        final icon = [_getPaddedSupportIcon('assets/icons/schooltalk_pe.png', active: isActivated && !pa.SCHOOL_VISIT_PE_done), spacer];
         pa.SCHOOL_VISIT_PE_done ? icons.addAll(icon) : icons.insertAll(0, icon);
       }
       if (sps.PITSO_VISIT_PE_selected && pa.pitsoPEPossible) {
-        final icon = [_getPaddedIcon('assets/icons/pitso.png', color: pa.PITSO_VISIT_PE_done ? ICON_INACTIVE : iconColor), spacer];
+        final icon = [_getPaddedSupportIcon('assets/icons/pitso.png', active: isActivated && !pa.PITSO_VISIT_PE_done), spacer];
         pa.PITSO_VISIT_PE_done ? icons.addAll(icon) : icons.insertAll(0, icon);
       }
       if (sps.areAllDeselected) {
-        icons.add(_getPaddedIcon('assets/icons/no_support.png', color: iconColor));
+        icons.add(_getPaddedSupportIcon('assets/icons/no_support.png', active: isActivated));
         icons.add(spacer);
       } if (icons.isEmpty) {
         // indicate with '…' that options were selected which do not have an icon

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -403,8 +403,10 @@ class _PatientScreenState extends State<PatientScreen> {
       }
       List<Widget> supportOptions = [];
       if (sps.NURSE_CLINIC_selected) {
-        supportOptions.add(_buildSupportOption(SupportOption.NURSE_CLINIC().description,
+        supportOptions.add(_buildSupportOption(
+          SupportOption.NURSE_CLINIC().description,
           checkboxState: _pa.NURSE_CLINIC_done,
+          doneText: 'done ${formatDateAndTimeTodayYesterday(_pa.NURSE_CLINIC_done_date)}',
           onChanged: (bool newState) {
             setState(() {
               _pa.set_NURSE_CLINIC_done(newState);
@@ -415,8 +417,10 @@ class _PatientScreenState extends State<PatientScreen> {
         ));
       }
       if (sps.SATURDAY_CLINIC_CLUB_selected && _pa.saturdayClinicClubAvailable) {
-        supportOptions.add(_buildSupportOption(SupportOption.SATURDAY_CLINIC_CLUB().description,
+        supportOptions.add(_buildSupportOption(
+          SupportOption.SATURDAY_CLINIC_CLUB().description,
           checkboxState: _pa.SATURDAY_CLINIC_CLUB_done,
+          doneText: 'done ${formatDateAndTimeTodayYesterday(_pa.SATURDAY_CLINIC_CLUB_done_date)}',
           onChanged: (bool newState) {
             setState(() {
               _pa.set_SATURDAY_CLINIC_CLUB_done(newState);
@@ -427,8 +431,10 @@ class _PatientScreenState extends State<PatientScreen> {
         ));
       }
       if (sps.COMMUNITY_YOUTH_CLUB_selected && _pa.communityYouthClubAvailable) {
-        supportOptions.add(_buildSupportOption(SupportOption.COMMUNITY_YOUTH_CLUB().description,
+        supportOptions.add(_buildSupportOption(
+          SupportOption.COMMUNITY_YOUTH_CLUB().description,
           checkboxState: _pa.COMMUNITY_YOUTH_CLUB_done,
+          doneText: 'done ${formatDateAndTimeTodayYesterday(_pa.COMMUNITY_YOUTH_CLUB_done_date)}',
           onChanged: (bool newState) {
             setState(() {
               _pa.set_COMMUNITY_YOUTH_CLUB_done(newState);
@@ -439,8 +445,10 @@ class _PatientScreenState extends State<PatientScreen> {
         ));
       }
       if (sps.PHONE_CALL_PE_selected) {
-        supportOptions.add(_buildSupportOption(SupportOption.PHONE_CALL_PE().description,
+        supportOptions.add(_buildSupportOption(
+          SupportOption.PHONE_CALL_PE().description,
           checkboxState: _pa.PHONE_CALL_PE_done,
+          doneText: 'done ${formatDateAndTimeTodayYesterday(_pa.PHONE_CALL_PE_done_date)}',
           onChanged: (bool newState) {
             setState(() {
               _pa.set_PHONE_CALL_PE_done(newState);
@@ -451,8 +459,10 @@ class _PatientScreenState extends State<PatientScreen> {
         ));
       }
       if (sps.HOME_VISIT_PE_selected && _pa.homeVisitPEPossible) {
-        supportOptions.add(_buildSupportOption(SupportOption.HOME_VISIT_PE().description,
+        supportOptions.add(_buildSupportOption(
+          SupportOption.HOME_VISIT_PE().description,
           checkboxState: _pa.HOME_VISIT_PE_done,
+          doneText: 'done ${formatDateAndTimeTodayYesterday(_pa.HOME_VISIT_PE_done_date)}',
           onChanged: (bool newState) {
             setState(() {
               _pa.set_HOME_VISIT_PE_done(newState);
@@ -465,8 +475,10 @@ class _PatientScreenState extends State<PatientScreen> {
       if (sps.SCHOOL_VISIT_PE_selected && _pa.schoolVisitPEPossible) {
         String schoolNameAndVillage = _patient.latestPreferenceAssessment?.school;
         schoolNameAndVillage = schoolNameAndVillage == null ? '' : '\n($schoolNameAndVillage)';
-        supportOptions.add(_buildSupportOption(SupportOption.SCHOOL_VISIT_PE().description + schoolNameAndVillage,
+        supportOptions.add(_buildSupportOption(
+          SupportOption.SCHOOL_VISIT_PE().description + schoolNameAndVillage,
           checkboxState: _pa.SCHOOL_VISIT_PE_done,
+          doneText: 'done ${formatDateAndTimeTodayYesterday(_pa.SCHOOL_VISIT_PE_done_date)}',
           onChanged: (bool newState) {
             setState(() {
               _pa.set_SCHOOL_VISIT_PE_done(newState);
@@ -477,8 +489,10 @@ class _PatientScreenState extends State<PatientScreen> {
         ));
       }
       if (sps.PITSO_VISIT_PE_selected && _pa.pitsoPEPossible) {
-        supportOptions.add(_buildSupportOption(SupportOption.PITSO_VISIT_PE().description,
+        supportOptions.add(_buildSupportOption(
+          SupportOption.PITSO_VISIT_PE().description,
           checkboxState: _pa.PITSO_VISIT_PE_done,
+          doneText: 'done ${formatDateAndTimeTodayYesterday(_pa.PITSO_VISIT_PE_done_date)}',
           onChanged: (bool newState) {
             setState(() {
               _pa.set_PITSO_VISIT_PE_done(newState);
@@ -489,8 +503,10 @@ class _PatientScreenState extends State<PatientScreen> {
         ));
       }
       if (sps.CONDOM_DEMO_selected) {
-        supportOptions.add(_buildSupportOption(SupportOption.CONDOM_DEMO().description,
+        supportOptions.add(_buildSupportOption(
+          SupportOption.CONDOM_DEMO().description,
           checkboxState: _pa.CONDOM_DEMO_done,
+          doneText: 'done ${formatDateAndTimeTodayYesterday(_pa.CONDOM_DEMO_done_date)}',
           onChanged: (bool newState) {
             setState(() {
               _pa.set_CONDOM_DEMO_done(newState);
@@ -500,8 +516,10 @@ class _PatientScreenState extends State<PatientScreen> {
         ));
       }
       if (sps.CONTRACEPTIVES_INFO_selected) {
-        supportOptions.add(_buildSupportOption(SupportOption.CONTRACEPTIVES_INFO().description,
+        supportOptions.add(_buildSupportOption(
+          SupportOption.CONTRACEPTIVES_INFO().description,
           checkboxState: _pa.CONTRACEPTIVES_INFO_done,
+          doneText: 'done ${formatDateAndTimeTodayYesterday(_pa.CONTRACEPTIVES_INFO_done_date)}',
           onChanged: (bool newState) {
             setState(() {
               _pa.set_CONTRACEPTIVES_INFO_done(newState);
@@ -511,8 +529,10 @@ class _PatientScreenState extends State<PatientScreen> {
         ));
       }
       if (sps.VMMC_INFO_selected) {
-        supportOptions.add(_buildSupportOption(SupportOption.VMMC_INFO().description,
+        supportOptions.add(_buildSupportOption(
+          SupportOption.VMMC_INFO().description,
           checkboxState: _pa.VMMC_INFO_done,
+          doneText: 'done ${formatDateAndTimeTodayYesterday(_pa.VMMC_INFO_done_date)}',
           onChanged: (bool newState) {
             setState(() {
               _pa.set_VMMC_INFO_done(newState);
@@ -522,8 +542,10 @@ class _PatientScreenState extends State<PatientScreen> {
         ));
       }
       if (sps.YOUNG_MOTHERS_GROUP_selected && _pa.youngMothersAvailable) {
-        supportOptions.add(_buildSupportOption(SupportOption.YOUNG_MOTHERS_GROUP().description,
+        supportOptions.add(_buildSupportOption(
+          SupportOption.YOUNG_MOTHERS_GROUP().description,
           checkboxState: _pa.YOUNG_MOTHERS_GROUP_done,
+          doneText: 'done ${formatDateAndTimeTodayYesterday(_pa.YOUNG_MOTHERS_GROUP_done_date)}',
           onChanged: (bool newState) {
             setState(() {
               _pa.set_YOUNG_MOTHERS_GROUP_done(newState);
@@ -533,8 +555,10 @@ class _PatientScreenState extends State<PatientScreen> {
         ));
       }
       if (sps.FEMALE_WORTH_GROUP_selected && _pa.femaleWorthAvailable) {
-        supportOptions.add(_buildSupportOption(SupportOption.FEMALE_WORTH_GROUP().description,
+        supportOptions.add(_buildSupportOption(
+          SupportOption.FEMALE_WORTH_GROUP().description,
           checkboxState: _pa.FEMALE_WORTH_GROUP_done,
+          doneText: 'done ${formatDateAndTimeTodayYesterday(_pa.FEMALE_WORTH_GROUP_done_date)}',
           onChanged: (bool newState) {
             setState(() {
               _pa.set_FEMALE_WORTH_GROUP_done(newState);
@@ -544,8 +568,10 @@ class _PatientScreenState extends State<PatientScreen> {
         ));
       }
       if (sps.LEGAL_AID_INFO_selected && _pa.legalAidSmartphoneAvailable) {
-        supportOptions.add(_buildSupportOption(SupportOption.LEGAL_AID_INFO().description,
+        supportOptions.add(_buildSupportOption(
+          SupportOption.LEGAL_AID_INFO().description,
           checkboxState: _pa.LEGAL_AID_INFO_done,
+          doneText: 'done ${formatDateAndTimeTodayYesterday(_pa.LEGAL_AID_INFO_done_date)}',
           onChanged: (bool newState) {
             setState(() {
               _pa.set_LEGAL_AID_INFO_done(newState);

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -414,9 +414,6 @@ class _PatientScreenState extends State<PatientScreen> {
           ),
         );
       }
-      if (sps.areAllWithTodoDeselected) {
-        return _buildRow('Support', '—');
-      }
       List<Widget> supportOptions = [];
       if (sps.NURSE_CLINIC_selected) {
         supportOptions.add(_buildSupportOption(SupportPreferencesSelection.NURSE_CLINIC_DESCRIPTION,

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -10,6 +10,7 @@ import 'package:pebrapp/components/ViralLoadBadge.dart';
 import 'package:pebrapp/database/DatabaseProvider.dart';
 import 'package:pebrapp/database/beans/ARTRefillOption.dart';
 import 'package:pebrapp/database/beans/Gender.dart';
+import 'package:pebrapp/database/beans/SupportOption.dart';
 import 'package:pebrapp/database/beans/SupportPreferencesSelection.dart';
 import 'package:pebrapp/database/beans/ViralLoadSource.dart';
 import 'package:pebrapp/database/beans/YesNoRefused.dart';
@@ -43,20 +44,6 @@ class _PatientScreenState extends State<PatientScreen> {
   String _nextRefillText = '—';
   String _nextEndpointText = '—';
   double _screenWidth;
-
-  bool NURSE_CLINIC_done = false;
-  bool SATURDAY_CLINIC_CLUB_done = false;
-  bool COMMUNITY_YOUTH_CLUB_done = false;
-  bool PHONE_CALL_PE_done = false;
-  bool HOME_VISIT_PE_done = false;
-  bool SCHOOL_VISIT_PE_done = false;
-  bool PITSO_VISIT_PE_done = false;
-  bool CONDOM_DEMO_done = false;
-  bool CONTRACEPTIVES_INFO_done = false;
-  bool VMMC_INFO_done = false;
-  bool YOUNG_MOTHERS_GROUP_done = false;
-  bool FEMALE_WORTH_GROUP_done = false;
-  bool LEGAL_AID_INFO_done = false;
 
   StreamSubscription<AppState> _appStateStream;
 
@@ -409,97 +396,162 @@ class _PatientScreenState extends State<PatientScreen> {
             children: [
             _getPaddedIcon('assets/icons/no_support.png', width: iconWidth, height: iconHeight),
             SizedBox(width: 5.0),
-            Text(SupportPreferencesSelection.NONE_DESCRIPTION),
+            Text(SupportOption.NONE().description),
             ],
           ),
         );
       }
       List<Widget> supportOptions = [];
       if (sps.NURSE_CLINIC_selected) {
-        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.NURSE_CLINIC_DESCRIPTION,
-          checkboxState: NURSE_CLINIC_done,
-          onChanged: (bool newState) { setState(() { NURSE_CLINIC_done = newState; }); },
-          icon: _getPaddedIcon('assets/icons/nurse_clinic.png', width: iconWidth, height: iconHeight, color: NURSE_CLINIC_done ? ICON_INACTIVE : ICON_ACTIVE),
+        supportOptions.add(_buildSupportOption(SupportOption.NURSE_CLINIC().description,
+          checkboxState: _pa.NURSE_CLINIC_done,
+          onChanged: (bool newState) {
+            setState(() {
+              _pa.set_NURSE_CLINIC_done(newState);
+            });
+            return;
+          },
+          icon: _getPaddedIcon('assets/icons/nurse_clinic.png', width: iconWidth, height: iconHeight, color: _pa.NURSE_CLINIC_done ? ICON_INACTIVE : ICON_ACTIVE),
         ));
       }
       if (sps.SATURDAY_CLINIC_CLUB_selected && _pa.saturdayClinicClubAvailable) {
-        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.SATURDAY_CLINIC_CLUB_DESCRIPTION,
-          checkboxState: SATURDAY_CLINIC_CLUB_done,
-          onChanged: (bool newState) { setState(() { SATURDAY_CLINIC_CLUB_done = newState; }); },
-          icon: _getPaddedIcon('assets/icons/saturday_clinic_club.png', width: iconWidth, height: iconHeight, color: SATURDAY_CLINIC_CLUB_done ? ICON_INACTIVE : ICON_ACTIVE),
+        supportOptions.add(_buildSupportOption(SupportOption.SATURDAY_CLINIC_CLUB().description,
+          checkboxState: _pa.SATURDAY_CLINIC_CLUB_done,
+          onChanged: (bool newState) {
+            setState(() {
+              _pa.set_SATURDAY_CLINIC_CLUB_done(newState);
+            });
+            return;
+          },
+          icon: _getPaddedIcon('assets/icons/saturday_clinic_club.png', width: iconWidth, height: iconHeight, color: _pa.SATURDAY_CLINIC_CLUB_done ? ICON_INACTIVE : ICON_ACTIVE),
         ));
       }
       if (sps.COMMUNITY_YOUTH_CLUB_selected && _pa.communityYouthClubAvailable) {
-        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.COMMUNITY_YOUTH_CLUB_DESCRIPTION,
-          checkboxState: COMMUNITY_YOUTH_CLUB_done,
-          onChanged: (bool newState) { setState(() { COMMUNITY_YOUTH_CLUB_done = newState; }); },
-          icon: _getPaddedIcon('assets/icons/youth_club.png', width: iconWidth, height: iconHeight, color: COMMUNITY_YOUTH_CLUB_done ? ICON_INACTIVE : ICON_ACTIVE),
+        supportOptions.add(_buildSupportOption(SupportOption.COMMUNITY_YOUTH_CLUB().description,
+          checkboxState: _pa.COMMUNITY_YOUTH_CLUB_done,
+          onChanged: (bool newState) {
+            setState(() {
+              _pa.set_COMMUNITY_YOUTH_CLUB_done(newState);
+            });
+            return;
+          },
+          icon: _getPaddedIcon('assets/icons/youth_club.png', width: iconWidth, height: iconHeight, color: _pa.COMMUNITY_YOUTH_CLUB_done ? ICON_INACTIVE : ICON_ACTIVE),
         ));
       }
       if (sps.PHONE_CALL_PE_selected) {
-        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.PHONE_CALL_PE_DESCRIPTION,
-          checkboxState: PHONE_CALL_PE_done,
-          onChanged: (bool newState) { setState(() { PHONE_CALL_PE_done = newState; }); },
-          icon: _getPaddedIcon('assets/icons/phonecall_pe.png', width: iconWidth, height: iconHeight, color: PHONE_CALL_PE_done ? ICON_INACTIVE : ICON_ACTIVE),
+        supportOptions.add(_buildSupportOption(SupportOption.PHONE_CALL_PE().description,
+          checkboxState: _pa.PHONE_CALL_PE_done,
+          onChanged: (bool newState) {
+            setState(() {
+              _pa.set_PHONE_CALL_PE_done(newState);
+            });
+            return;
+          },
+          icon: _getPaddedIcon('assets/icons/phonecall_pe.png', width: iconWidth, height: iconHeight, color: _pa.PHONE_CALL_PE_done ? ICON_INACTIVE : ICON_ACTIVE),
         ));
       }
       if (sps.HOME_VISIT_PE_selected && _pa.homeVisitPEPossible) {
-        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.HOME_VISIT_PE_DESCRIPTION,
-          checkboxState: HOME_VISIT_PE_done,
-          onChanged: (bool newState) { setState(() { HOME_VISIT_PE_done = newState; }); },
-          icon: _getPaddedIcon('assets/icons/homevisit_pe.png', width: iconWidth, height: iconHeight, color: HOME_VISIT_PE_done ? ICON_INACTIVE : ICON_ACTIVE),
+        supportOptions.add(_buildSupportOption(SupportOption.HOME_VISIT_PE().description,
+          checkboxState: _pa.HOME_VISIT_PE_done,
+          onChanged: (bool newState) {
+            setState(() {
+              _pa.set_HOME_VISIT_PE_done(newState);
+            });
+            return;
+          },
+          icon: _getPaddedIcon('assets/icons/homevisit_pe.png', width: iconWidth, height: iconHeight, color: _pa.HOME_VISIT_PE_done ? ICON_INACTIVE : ICON_ACTIVE),
         ));
       }
       if (sps.SCHOOL_VISIT_PE_selected && _pa.schoolVisitPEPossible) {
         String schoolNameAndVillage = _patient.latestPreferenceAssessment?.school;
         schoolNameAndVillage = schoolNameAndVillage == null ? '' : '\n($schoolNameAndVillage)';
-        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.SCHOOL_VISIT_PE_DESCRIPTION + schoolNameAndVillage,
-          checkboxState: SCHOOL_VISIT_PE_done,
-          onChanged: (bool newState) { setState(() { SCHOOL_VISIT_PE_done = newState; }); },
-          icon: _getPaddedIcon('assets/icons/schooltalk_pe.png', width: iconWidth, height: iconHeight, color: SCHOOL_VISIT_PE_done ? ICON_INACTIVE : ICON_ACTIVE),
+        supportOptions.add(_buildSupportOption(SupportOption.SCHOOL_VISIT_PE().description + schoolNameAndVillage,
+          checkboxState: _pa.SCHOOL_VISIT_PE_done,
+          onChanged: (bool newState) {
+            setState(() {
+              _pa.set_SCHOOL_VISIT_PE_done(newState);
+            });
+            return;
+          },
+          icon: _getPaddedIcon('assets/icons/schooltalk_pe.png', width: iconWidth, height: iconHeight, color: _pa.SCHOOL_VISIT_PE_done ? ICON_INACTIVE : ICON_ACTIVE),
         ));
       }
       if (sps.PITSO_VISIT_PE_selected && _pa.pitsoPEPossible) {
-        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.PITSO_VISIT_PE_DESCRIPTION,
-          checkboxState: PITSO_VISIT_PE_done,
-          onChanged: (bool newState) { setState(() { PITSO_VISIT_PE_done = newState; }); },
-          icon: _getPaddedIcon('assets/icons/pitso.png', width: iconWidth, height: iconHeight, color: PITSO_VISIT_PE_done ? ICON_INACTIVE : ICON_ACTIVE),
+        supportOptions.add(_buildSupportOption(SupportOption.PITSO_VISIT_PE().description,
+          checkboxState: _pa.PITSO_VISIT_PE_done,
+          onChanged: (bool newState) {
+            setState(() {
+              _pa.set_PITSO_VISIT_PE_done(newState);
+            });
+            return;
+          },
+          icon: _getPaddedIcon('assets/icons/pitso.png', width: iconWidth, height: iconHeight, color: _pa.PITSO_VISIT_PE_done ? ICON_INACTIVE : ICON_ACTIVE),
         ));
       }
       if (sps.CONDOM_DEMO_selected) {
-        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.CONDOM_DEMO_DESCRIPTION,
-          checkboxState: CONDOM_DEMO_done,
-          onChanged: (bool newState) { setState(() { CONDOM_DEMO_done = newState; }); },
+        supportOptions.add(_buildSupportOption(SupportOption.CONDOM_DEMO().description,
+          checkboxState: _pa.CONDOM_DEMO_done,
+          onChanged: (bool newState) {
+            setState(() {
+              _pa.set_CONDOM_DEMO_done(newState);
+            });
+            return;
+          },
         ));
       }
       if (sps.CONTRACEPTIVES_INFO_selected) {
-        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.CONTRACEPTIVES_INFO_DESCRIPTION,
-          checkboxState: CONTRACEPTIVES_INFO_done,
-          onChanged: (bool newState) { setState(() { CONTRACEPTIVES_INFO_done = newState; }); },
+        supportOptions.add(_buildSupportOption(SupportOption.CONTRACEPTIVES_INFO().description,
+          checkboxState: _pa.CONTRACEPTIVES_INFO_done,
+          onChanged: (bool newState) {
+            setState(() {
+              _pa.set_CONTRACEPTIVES_INFO_done(newState);
+            });
+            return;
+          },
         ));
       }
       if (sps.VMMC_INFO_selected) {
-        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.VMMC_INFO_DESCRIPTION,
-          checkboxState: VMMC_INFO_done,
-          onChanged: (bool newState) { setState(() { VMMC_INFO_done = newState; }); },
+        supportOptions.add(_buildSupportOption(SupportOption.VMMC_INFO().description,
+          checkboxState: _pa.VMMC_INFO_done,
+          onChanged: (bool newState) {
+            setState(() {
+              _pa.set_VMMC_INFO_done(newState);
+            });
+            return;
+          },
         ));
       }
       if (sps.YOUNG_MOTHERS_GROUP_selected && _pa.youngMothersAvailable) {
-        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.YOUNG_MOTHERS_GROUP_DESCRIPTION,
-          checkboxState: YOUNG_MOTHERS_GROUP_done,
-          onChanged: (bool newState) { setState(() { YOUNG_MOTHERS_GROUP_done = newState; }); },
+        supportOptions.add(_buildSupportOption(SupportOption.YOUNG_MOTHERS_GROUP().description,
+          checkboxState: _pa.YOUNG_MOTHERS_GROUP_done,
+          onChanged: (bool newState) {
+            setState(() {
+              _pa.set_YOUNG_MOTHERS_GROUP_done(newState);
+            });
+            return;
+          },
         ));
       }
       if (sps.FEMALE_WORTH_GROUP_selected && _pa.femaleWorthAvailable) {
-        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.FEMALE_WORTH_GROUP_DESCRIPTION,
-          checkboxState: FEMALE_WORTH_GROUP_done,
-          onChanged: (bool newState) { setState(() { FEMALE_WORTH_GROUP_done = newState; }); },
+        supportOptions.add(_buildSupportOption(SupportOption.FEMALE_WORTH_GROUP().description,
+          checkboxState: _pa.FEMALE_WORTH_GROUP_done,
+          onChanged: (bool newState) {
+            setState(() {
+              _pa.set_FEMALE_WORTH_GROUP_done(newState);
+            });
+            return;
+          },
         ));
       }
       if (sps.LEGAL_AID_INFO_selected && _pa.legalAidSmartphoneAvailable) {
-        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.LEGAL_AID_INFO_DESCRIPTION,
-          checkboxState: LEGAL_AID_INFO_done,
-          onChanged: (bool newState) { setState(() { LEGAL_AID_INFO_done = newState; }); },
+        supportOptions.add(_buildSupportOption(SupportOption.LEGAL_AID_INFO().description,
+          checkboxState: _pa.LEGAL_AID_INFO_done,
+          onChanged: (bool newState) {
+            setState(() {
+              _pa.set_LEGAL_AID_INFO_done(newState);
+            });
+            return;
+          },
         ));
       }
 

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -50,6 +50,12 @@ class _PatientScreenState extends State<PatientScreen> {
   bool HOME_VISIT_PE_done = false;
   bool SCHOOL_VISIT_PE_done = false;
   bool PITSO_VISIT_PE_done = false;
+  bool CONDOM_DEMO_done = false;
+  bool CONTRACEPTIVES_INFO_done = false;
+  bool VMMC_INFO_done = false;
+  bool YOUNG_MOTHERS_GROUP_done = false;
+  bool FEMALE_WORTH_GROUP_done = false;
+  bool LEGAL_AID_INFO_done = false;
 
   StreamSubscription<AppState> _appStateStream;
 
@@ -459,6 +465,42 @@ class _PatientScreenState extends State<PatientScreen> {
           checkboxState: PITSO_VISIT_PE_done,
           onChanged: (bool newState) { setState(() { PITSO_VISIT_PE_done = newState; }); },
           icon: _getPaddedIcon('assets/icons/pitso.png', width: iconWidth, height: iconHeight, color: PITSO_VISIT_PE_done ? ICON_INACTIVE : ICON_ACTIVE),
+        ));
+      }
+      if (sps.CONDOM_DEMO_selected) {
+        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.CONDOM_DEMO_DESCRIPTION,
+          checkboxState: CONDOM_DEMO_done,
+          onChanged: (bool newState) { setState(() { CONDOM_DEMO_done = newState; }); },
+        ));
+      }
+      if (sps.CONTRACEPTIVES_INFO_selected) {
+        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.CONTRACEPTIVES_INFO_DESCRIPTION,
+          checkboxState: CONTRACEPTIVES_INFO_done,
+          onChanged: (bool newState) { setState(() { CONTRACEPTIVES_INFO_done = newState; }); },
+        ));
+      }
+      if (sps.VMMC_INFO_selected) {
+        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.VMMC_INFO_DESCRIPTION,
+          checkboxState: VMMC_INFO_done,
+          onChanged: (bool newState) { setState(() { VMMC_INFO_done = newState; }); },
+        ));
+      }
+      if (sps.YOUNG_MOTHERS_GROUP_selected) {
+        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.YOUNG_MOTHERS_GROUP_DESCRIPTION,
+          checkboxState: YOUNG_MOTHERS_GROUP_done,
+          onChanged: (bool newState) { setState(() { YOUNG_MOTHERS_GROUP_done = newState; }); },
+        ));
+      }
+      if (sps.FEMALE_WORTH_GROUP_selected) {
+        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.FEMALE_WORTH_GROUP_DESCRIPTION,
+          checkboxState: FEMALE_WORTH_GROUP_done,
+          onChanged: (bool newState) { setState(() { FEMALE_WORTH_GROUP_done = newState; }); },
+        ));
+      }
+      if (sps.LEGAL_AID_INFO_selected) {
+        supportOptions.add(_buildSupportOption(SupportPreferencesSelection.LEGAL_AID_INFO_DESCRIPTION,
+          checkboxState: LEGAL_AID_INFO_done,
+          onChanged: (bool newState) { setState(() { LEGAL_AID_INFO_done = newState; }); },
         ));
       }
 

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -14,6 +14,7 @@ import 'package:pebrapp/database/beans/SupportPreferencesSelection.dart';
 import 'package:pebrapp/database/beans/ViralLoadSource.dart';
 import 'package:pebrapp/database/beans/YesNoRefused.dart';
 import 'package:pebrapp/database/models/Patient.dart';
+import 'package:pebrapp/database/models/PreferenceAssessment.dart';
 import 'package:pebrapp/database/models/RequiredAction.dart';
 import 'package:pebrapp/database/models/ViralLoad.dart';
 import 'package:pebrapp/screens/ARTRefillScreen.dart';
@@ -398,7 +399,8 @@ class _PatientScreenState extends State<PatientScreen> {
   _buildPreferencesCard() {
 
     Widget _buildSupportOptions() {
-      final SupportPreferencesSelection sps = _patient.latestPreferenceAssessment.supportPreferences;
+      final PreferenceAssessment _pa = _patient.latestPreferenceAssessment;
+      final SupportPreferencesSelection sps = _pa.supportPreferences;
       final double iconWidth = 28.0;
       final double iconHeight = 28.0;
       if (sps.areAllDeselected) {
@@ -423,14 +425,14 @@ class _PatientScreenState extends State<PatientScreen> {
           icon: _getPaddedIcon('assets/icons/nurse_clinic.png', width: iconWidth, height: iconHeight, color: NURSE_CLINIC_done ? ICON_INACTIVE : ICON_ACTIVE),
         ));
       }
-      if (sps.SATURDAY_CLINIC_CLUB_selected) {
+      if (sps.SATURDAY_CLINIC_CLUB_selected && _pa.saturdayClinicClubAvailable) {
         supportOptions.add(_buildSupportOption(SupportPreferencesSelection.SATURDAY_CLINIC_CLUB_DESCRIPTION,
           checkboxState: SATURDAY_CLINIC_CLUB_done,
           onChanged: (bool newState) { setState(() { SATURDAY_CLINIC_CLUB_done = newState; }); },
           icon: _getPaddedIcon('assets/icons/saturday_clinic_club.png', width: iconWidth, height: iconHeight, color: SATURDAY_CLINIC_CLUB_done ? ICON_INACTIVE : ICON_ACTIVE),
         ));
       }
-      if (sps.COMMUNITY_YOUTH_CLUB_selected) {
+      if (sps.COMMUNITY_YOUTH_CLUB_selected && _pa.communityYouthClubAvailable) {
         supportOptions.add(_buildSupportOption(SupportPreferencesSelection.COMMUNITY_YOUTH_CLUB_DESCRIPTION,
           checkboxState: COMMUNITY_YOUTH_CLUB_done,
           onChanged: (bool newState) { setState(() { COMMUNITY_YOUTH_CLUB_done = newState; }); },
@@ -444,14 +446,14 @@ class _PatientScreenState extends State<PatientScreen> {
           icon: _getPaddedIcon('assets/icons/phonecall_pe.png', width: iconWidth, height: iconHeight, color: PHONE_CALL_PE_done ? ICON_INACTIVE : ICON_ACTIVE),
         ));
       }
-      if (sps.HOME_VISIT_PE_selected) {
+      if (sps.HOME_VISIT_PE_selected && _pa.homeVisitPEPossible) {
         supportOptions.add(_buildSupportOption(SupportPreferencesSelection.HOME_VISIT_PE_DESCRIPTION,
           checkboxState: HOME_VISIT_PE_done,
           onChanged: (bool newState) { setState(() { HOME_VISIT_PE_done = newState; }); },
           icon: _getPaddedIcon('assets/icons/homevisit_pe.png', width: iconWidth, height: iconHeight, color: HOME_VISIT_PE_done ? ICON_INACTIVE : ICON_ACTIVE),
         ));
       }
-      if (sps.SCHOOL_VISIT_PE_selected) {
+      if (sps.SCHOOL_VISIT_PE_selected && _pa.schoolVisitPEPossible) {
         String schoolNameAndVillage = _patient.latestPreferenceAssessment?.school;
         schoolNameAndVillage = schoolNameAndVillage == null ? '' : '\n($schoolNameAndVillage)';
         supportOptions.add(_buildSupportOption(SupportPreferencesSelection.SCHOOL_VISIT_PE_DESCRIPTION + schoolNameAndVillage,
@@ -460,7 +462,7 @@ class _PatientScreenState extends State<PatientScreen> {
           icon: _getPaddedIcon('assets/icons/schooltalk_pe.png', width: iconWidth, height: iconHeight, color: SCHOOL_VISIT_PE_done ? ICON_INACTIVE : ICON_ACTIVE),
         ));
       }
-      if (sps.PITSO_VISIT_PE_selected) {
+      if (sps.PITSO_VISIT_PE_selected && _pa.pitsoPEPossible) {
         supportOptions.add(_buildSupportOption(SupportPreferencesSelection.PITSO_VISIT_PE_DESCRIPTION,
           checkboxState: PITSO_VISIT_PE_done,
           onChanged: (bool newState) { setState(() { PITSO_VISIT_PE_done = newState; }); },
@@ -485,19 +487,19 @@ class _PatientScreenState extends State<PatientScreen> {
           onChanged: (bool newState) { setState(() { VMMC_INFO_done = newState; }); },
         ));
       }
-      if (sps.YOUNG_MOTHERS_GROUP_selected) {
+      if (sps.YOUNG_MOTHERS_GROUP_selected && _pa.youngMothersAvailable) {
         supportOptions.add(_buildSupportOption(SupportPreferencesSelection.YOUNG_MOTHERS_GROUP_DESCRIPTION,
           checkboxState: YOUNG_MOTHERS_GROUP_done,
           onChanged: (bool newState) { setState(() { YOUNG_MOTHERS_GROUP_done = newState; }); },
         ));
       }
-      if (sps.FEMALE_WORTH_GROUP_selected) {
+      if (sps.FEMALE_WORTH_GROUP_selected && _pa.femaleWorthAvailable) {
         supportOptions.add(_buildSupportOption(SupportPreferencesSelection.FEMALE_WORTH_GROUP_DESCRIPTION,
           checkboxState: FEMALE_WORTH_GROUP_done,
           onChanged: (bool newState) { setState(() { FEMALE_WORTH_GROUP_done = newState; }); },
         ));
       }
-      if (sps.LEGAL_AID_INFO_selected) {
+      if (sps.LEGAL_AID_INFO_selected && _pa.legalAidSmartphoneAvailable) {
         supportOptions.add(_buildSupportOption(SupportPreferencesSelection.LEGAL_AID_INFO_DESCRIPTION,
           checkboxState: LEGAL_AID_INFO_done,
           onChanged: (bool newState) { setState(() { LEGAL_AID_INFO_done = newState; }); },

--- a/lib/screens/PreferenceAssessmentScreen.dart
+++ b/lib/screens/PreferenceAssessmentScreen.dart
@@ -15,6 +15,7 @@ import 'package:pebrapp/database/beans/PEHomeDeliveryNotPossibleReason.dart';
 import 'package:pebrapp/database/beans/PhoneAvailability.dart';
 import 'package:pebrapp/database/beans/PitsoPENotPossibleReason.dart';
 import 'package:pebrapp/database/beans/SchoolVisitPENotPossibleReason.dart';
+import 'package:pebrapp/database/beans/SupportOption.dart';
 import 'package:pebrapp/database/beans/SupportPreferencesSelection.dart';
 import 'package:pebrapp/database/beans/VLSuppressedMessage.dart';
 import 'package:pebrapp/database/beans/VLUnsuppressedMessage.dart';
@@ -1016,7 +1017,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
       _makeQuestion('What kind of support do you mainly wish? (tick all that apply)',
         answer: CheckboxListTile(
             secondary: _getPaddedIcon('assets/icons/nurse_clinic.png'),
-            title: Text(SupportPreferencesSelection.NURSE_CLINIC_DESCRIPTION),
+            title: Text(SupportOption.NURSE_CLINIC().description),
 //            dense: true,
             value: _pa.supportPreferences.NURSE_CLINIC_selected,
             onChanged: (bool newValue) => this.setState(() {
@@ -1026,7 +1027,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
       _makeQuestion('',
         answer: CheckboxListTile(
             secondary: _getPaddedIcon('assets/icons/saturday_clinic_club.png'),
-            title: Text(SupportPreferencesSelection.SATURDAY_CLINIC_CLUB_DESCRIPTION),
+            title: Text(SupportOption.SATURDAY_CLINIC_CLUB().description),
             value: _pa.supportPreferences.SATURDAY_CLINIC_CLUB_selected,
             onChanged: (bool newValue) => this.setState(() {
               _pa.supportPreferences.SATURDAY_CLINIC_CLUB_selected =
@@ -1037,7 +1038,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
       _makeQuestion('',
         answer: CheckboxListTile(
             secondary: _getPaddedIcon('assets/icons/youth_club.png'),
-            title: Text(SupportPreferencesSelection.COMMUNITY_YOUTH_CLUB_DESCRIPTION),
+            title: Text(SupportOption.COMMUNITY_YOUTH_CLUB().description),
             value: _pa.supportPreferences.COMMUNITY_YOUTH_CLUB_selected,
             onChanged: (bool newValue) => this.setState(() {
               _pa.supportPreferences.COMMUNITY_YOUTH_CLUB_selected =
@@ -1048,7 +1049,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
       _makeQuestion('',
         answer: CheckboxListTile(
             secondary: _getPaddedIcon('assets/icons/phonecall_pe.png'),
-            title: Text(SupportPreferencesSelection.PHONE_CALL_PE_DESCRIPTION),
+            title: Text(SupportOption.PHONE_CALL_PE().description),
             value: _pa.supportPreferences.PHONE_CALL_PE_selected,
             onChanged: (bool newValue) => this.setState(() {
               _pa.supportPreferences.PHONE_CALL_PE_selected = newValue;
@@ -1057,7 +1058,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
       _makeQuestion('',
         answer: CheckboxListTile(
             secondary: _getPaddedIcon('assets/icons/homevisit_pe.png'),
-            title: Text(SupportPreferencesSelection.HOME_VISIT_PE_DESCRIPTION),
+            title: Text(SupportOption.HOME_VISIT_PE().description),
             value: _pa.supportPreferences.HOME_VISIT_PE_selected,
             onChanged: (bool newValue) => this.setState(() {
               _pa.supportPreferences.HOME_VISIT_PE_selected = newValue;
@@ -1067,7 +1068,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
       _makeQuestion('',
         answer: CheckboxListTile(
             secondary: _getPaddedIcon('assets/icons/schooltalk_pe.png'),
-            title: Text(SupportPreferencesSelection.SCHOOL_VISIT_PE_DESCRIPTION),
+            title: Text(SupportOption.SCHOOL_VISIT_PE().description),
             value: _pa.supportPreferences.SCHOOL_VISIT_PE_selected,
             onChanged: (bool newValue) => this.setState(() {
               _pa.supportPreferences.SCHOOL_VISIT_PE_selected = newValue;
@@ -1077,7 +1078,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
       _makeQuestion('',
         answer: CheckboxListTile(
             secondary: _getPaddedIcon('assets/icons/pitso.png'),
-            title: Text(SupportPreferencesSelection.PITSO_VISIT_PE_DESCRIPTION),
+            title: Text(SupportOption.PITSO_VISIT_PE().description),
             value: _pa.supportPreferences.PITSO_VISIT_PE_selected,
             onChanged: (bool newValue) => this.setState(() {
               _pa.supportPreferences.PITSO_VISIT_PE_selected = newValue;
@@ -1087,7 +1088,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
       _makeQuestion('',
         answer: CheckboxListTile(
 //            secondary: Container(width: 0.0),
-            title: Text(SupportPreferencesSelection.CONDOM_DEMO_DESCRIPTION),
+            title: Text(SupportOption.CONDOM_DEMO().description),
             value: _pa.supportPreferences.CONDOM_DEMO_selected,
             onChanged: (bool newValue) => this.setState(() {
               _pa.supportPreferences.CONDOM_DEMO_selected = newValue;
@@ -1096,7 +1097,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
       _makeQuestion('',
         answer: CheckboxListTile(
 //            secondary: Container(width: 0.0),
-            title: Text(SupportPreferencesSelection.CONTRACEPTIVES_INFO_DESCRIPTION),
+            title: Text(SupportOption.CONTRACEPTIVES_INFO().description),
             value: _pa.supportPreferences.CONTRACEPTIVES_INFO_selected,
             onChanged: (bool newValue) => this.setState(() {
               _pa.supportPreferences.CONTRACEPTIVES_INFO_selected = newValue;
@@ -1106,7 +1107,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
       _makeQuestion('',
         answer: CheckboxListTile(
 //            secondary: Container(width: 0.0),
-            title: Text(SupportPreferencesSelection.VMMC_INFO_DESCRIPTION),
+            title: Text(SupportOption.VMMC_INFO().description),
             value: _pa.supportPreferences.VMMC_INFO_selected,
             onChanged: (bool newValue) => this.setState(() {
               _pa.supportPreferences.VMMC_INFO_selected = newValue;
@@ -1116,7 +1117,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
       _patient.gender == Gender.FEMALE() || _patient.gender == Gender.TRANSGENDER() ? _makeQuestion('',
         answer: CheckboxListTile(
 //            secondary: Container(width: 0.0),
-            title: Text(SupportPreferencesSelection.YOUNG_MOTHERS_GROUP_DESCRIPTION),
+            title: Text(SupportOption.YOUNG_MOTHERS_GROUP().description),
             value: _pa.supportPreferences.YOUNG_MOTHERS_GROUP_selected,
             onChanged: (bool newValue) => this.setState(() {
               _pa.supportPreferences.YOUNG_MOTHERS_GROUP_selected = newValue;
@@ -1126,7 +1127,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
       _patient.gender == Gender.FEMALE() || _patient.gender == Gender.TRANSGENDER() ? _makeQuestion('',
         answer: CheckboxListTile(
 //            secondary: Container(width: 0.0),
-            title: Text(SupportPreferencesSelection.FEMALE_WORTH_GROUP_DESCRIPTION),
+            title: Text(SupportOption.FEMALE_WORTH_GROUP().description),
             value: _pa.supportPreferences.FEMALE_WORTH_GROUP_selected,
             onChanged: (bool newValue) => this.setState(() {
               _pa.supportPreferences.FEMALE_WORTH_GROUP_selected = newValue;
@@ -1143,7 +1144,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
             )),
         answer: CheckboxListTile(
 //            secondary: Container(width: 0.0),
-            title: Text(SupportPreferencesSelection.LEGAL_AID_INFO_DESCRIPTION),
+            title: Text(SupportOption.LEGAL_AID_INFO().description),
             value: _pa.supportPreferences.LEGAL_AID_INFO_selected,
             onChanged: (bool newValue) => this.setState(() {
               _pa.supportPreferences.LEGAL_AID_INFO_selected = newValue;
@@ -1153,7 +1154,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
       _makeQuestion('',
         answer: CheckboxListTile(
             secondary: _getPaddedIcon('assets/icons/no_support.png'),
-            title: Text(SupportPreferencesSelection.NONE_DESCRIPTION),
+            title: Text(SupportOption.NONE().description),
             value: _pa.supportPreferences.areAllDeselected,
             onChanged: (bool newValue) {
               if (newValue) {

--- a/lib/screens/PreferenceAssessmentScreen.dart
+++ b/lib/screens/PreferenceAssessmentScreen.dart
@@ -105,6 +105,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
     _phoneAvailabilityBeforeAssessment = _patient.phoneAvailability;
     _patientPhoneNumberBeforeAssessment = _patient.phoneNumber;
     _pa.patientART = patient.artNumber;
+    _pa.supportPreferences = SupportPreferencesSelection.fromLastAssessment(_patient.latestPreferenceAssessment);
     DatabaseProvider().retrieveLatestUserData().then((UserData user) {
       _user = user;
       final String _existingPEPhoneNumber = _user.phoneNumber;
@@ -2045,7 +2046,7 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
       }
 
       print('NEW PREFERENCE ASSESSMENT (_id will be given by SQLite database):\n$_pa');
-      await DatabaseProvider().insertPreferenceAssessment(_pa);
+      _pa.id = await DatabaseProvider().insertPreferenceAssessment(_pa);
 
       final String newPEPhoneNumber = '+266-${_pePhoneNumberCtr.text}';
       if (newPEPhoneNumber != _user.phoneNumber) {

--- a/lib/utils/Utils.dart
+++ b/lib/utils/Utils.dart
@@ -142,6 +142,26 @@ String formatDate(DateTime date) {
   return DateFormat("dd.MM.yyyy").format(date.toLocal());
 }
 
+/// Turns a date into a formatted String. If the date is
+///
+/// * today it will return "Today, HH:mm"
+/// * yesterday it will return "Yesterday, HH:mm"
+/// * in the past it will return "dd.MM.yyyy HH:mm".
+///
+/// Returns null if [date] is null.
+String formatDateAndTimeTodayYesterday(DateTime date) {
+  if (date == null) {
+    return null;
+  }
+  final int daysFromToday = differenceInDays(DateTime.now(), date);
+  if (daysFromToday == 0) {
+    return "today, ${DateFormat("HH:mm").format(date.toLocal())}";
+  } else if (daysFromToday == -1) {
+    return "yesterday, ${DateFormat("HH:mm").format(date.toLocal())}";
+  }
+  return DateFormat("dd.MM.yyyy HH:mm").format(date.toLocal());
+}
+
 /// Turns a date into a formatted String with date and time. If the date is
 /// today it will return "Today, HH:mm". If the date was yesterday, it will
 /// return "Yesterday, HH:mm". If the date was before yesterday, it will return

--- a/test/unit_test/PreferenceAssessment_test.dart
+++ b/test/unit_test/PreferenceAssessment_test.dart
@@ -33,6 +33,41 @@ void main() {
       expect(sps.SCHOOL_VISIT_PE_selected, false);
     });
 
+    test('excel formatting', () {
+      var sps = SupportPreferencesSelection();
+      sps.NURSE_CLINIC_selected = true;
+      sps.SATURDAY_CLINIC_CLUB_selected = false;
+      sps.HOME_VISIT_PE_selected = true;
+      sps.PHONE_CALL_PE_selected = false;
+      sps.COMMUNITY_YOUTH_CLUB_selected = true;
+      sps.SCHOOL_VISIT_PE_selected = false;
+
+      final excelString = sps.toExcelString();
+      final expected = '1, 3, 5';
+      expect(excelString, expected);
+    });
+
+    test('excel formatting with None option', () {
+      var sps = SupportPreferencesSelection();
+      final excelString = sps.toExcelString();
+      final expected = '14';
+      expect(excelString, expected);
+    });
+
+    test('excel formatting with None option and some deselected', () {
+      var sps = SupportPreferencesSelection();
+      sps.NURSE_CLINIC_selected = false;
+      sps.SATURDAY_CLINIC_CLUB_selected = false;
+      sps.HOME_VISIT_PE_selected = false;
+      sps.PHONE_CALL_PE_selected = false;
+      sps.COMMUNITY_YOUTH_CLUB_selected = false;
+      sps.SCHOOL_VISIT_PE_selected = false;
+
+      final excelString = sps.toExcelString();
+      final expected = '14';
+      expect(excelString, expected);
+    });
+
   });
 
   group('Enums', () {


### PR DESCRIPTION
Closes #29.

- Stores done interactions in separate table and excel sheet.
- Displays date when done on patient screen.
- Show additional information for VMMC and Contraceptives options on patient screen.
- All selected options are displayed on the patient screen, if they are feasible/available.
- Icons of done support options are greyed out and pushed towards the back on main screen.
- Not done options are pre-selected in next assessment.
- If support options without an icon are selected show `…` on the main screen to indicate that there are more options selected.

Screenshots

![patient-screen](https://user-images.githubusercontent.com/24862276/61127349-4ed00b00-a4af-11e9-881c-18c5859ba3a4.png)

![main-screen](https://user-images.githubusercontent.com/24862276/61127350-4ed00b00-a4af-11e9-8dc9-a93d50395e33.png)
