### PR TITLE
63 remove emojis

### DIFF
--- a/lib/database/beans/AdherenceReminderMessage.dart
+++ b/lib/database/beans/AdherenceReminderMessage.dart
@@ -22,8 +22,8 @@ class AdherenceReminderMessage {
 
   // These are the descriptions that will be displayed in the UI.
   static const Map<_Message, String> _description = {
-    _Message.MESSAGE_1: "Meds time 🕒",
-    _Message.MESSAGE_2: "Nako ea lithlare 🕒",
+    _Message.MESSAGE_1: "Meds time",
+    _Message.MESSAGE_2: "Nako ea lithlare",
     _Message.MESSAGE_3: "Recharge!",
     _Message.MESSAGE_4: "Healthy living!",
     _Message.MESSAGE_5: "Bophelo bo botle!",

--- a/lib/database/beans/VLSuppressedMessage.dart
+++ b/lib/database/beans/VLSuppressedMessage.dart
@@ -19,7 +19,7 @@ class VLSuppressedMessage {
 
   // These are the descriptions that will be displayed in the UI.
   static const Map<_Message, String> _description = {
-    _Message.MESSAGE_1: "😊",
+    _Message.MESSAGE_1: ":-)",
     _Message.MESSAGE_2: "Well done, keep it up!",
     _Message.MESSAGE_3: "Hoooha!",
     _Message.MESSAGE_4: "GOT IT!",

--- a/lib/database/beans/VLUnsuppressedMessage.dart
+++ b/lib/database/beans/VLUnsuppressedMessage.dart
@@ -23,8 +23,8 @@ class VLUnsuppressedMessage {
     _Message.MESSAGE_2: "No leke. Etsa betere ka moso.",
     _Message.MESSAGE_3: "Ahhh!!!",
     _Message.MESSAGE_4: "OH NO!!!",
-    _Message.MESSAGE_5: "Battery low. Take action! 😑",
-    _Message.MESSAGE_6: "Battery e tlase. Etsa hohong! 😑",
+    _Message.MESSAGE_5: "Battery low. Take action! -.-'",
+    _Message.MESSAGE_6: "Battery e tlase. Etsa hohong! -.-'",
   };
 
   _Message _message;

--- a/lib/screens/PreferenceAssessmentScreen.dart
+++ b/lib/screens/PreferenceAssessmentScreen.dart
@@ -2003,13 +2003,13 @@ class _PreferenceAssessmentFormState extends State<PreferenceAssessmentForm> {
           && _artRefillOptionAvailable[_artRefillOptionSelections.indexOf(ARTRefillOption.VHW())]) {
         _pa.artRefillVHWName = _vhwNameCtr.text;
         _pa.artRefillVHWVillage = _vhwVillageCtr.text;
-        _pa.artRefillVHWPhoneNumber = '+266-${_vhwPhoneNumberCtr.text}';
+        _pa.artRefillVHWPhoneNumber = _vhwPhoneNumberCtr.text == '' ? null : '+266-${_vhwPhoneNumberCtr.text}';
       }
       if (_artRefillOptionSelections.contains(ARTRefillOption.TREATMENT_BUDDY())
           && _artRefillOptionAvailable[_artRefillOptionSelections.indexOf(ARTRefillOption.TREATMENT_BUDDY())]) {
-        _pa.artRefillTreatmentBuddyART = _treatmentBuddyARTNumberCtr.text;
-        _pa.artRefillTreatmentBuddyVillage = _treatmentBuddyVillageCtr.text;
-        _pa.artRefillTreatmentBuddyPhoneNumber = '+266-${_treatmentBuddyPhoneNumberCtr.text}';
+        _pa.artRefillTreatmentBuddyART = _treatmentBuddyARTNumberCtr.text == '' ? null : _treatmentBuddyARTNumberCtr.text;
+        _pa.artRefillTreatmentBuddyVillage = _treatmentBuddyVillageCtr.text == '' ? null : _treatmentBuddyVillageCtr.text;
+        _pa.artRefillTreatmentBuddyPhoneNumber = _treatmentBuddyPhoneNumberCtr.text == '' ? null : '+266-${_treatmentBuddyPhoneNumberCtr.text}';
       }
       if (_phoneAvailability != _phoneAvailabilityBeforeAssessment) {
         // if the new value is different from before the assessment we should


### PR DESCRIPTION
Closes #63.

- Replaced emojis with pure text emoticons.
- Fixed a bug where VHW's / Treatment Buddy's phone number would be stored as '+266' if left empty during the preference assessment.