### PR TITLE
70 warning logout transfer

### DIFF
--- a/lib/components/PEBRAButtonFlat.dart
+++ b/lib/components/PEBRAButtonFlat.dart
@@ -6,18 +6,20 @@ class PEBRAButtonFlat extends StatelessWidget {
   final String _buttonText;
   final onPressed;
   final Widget widget;
+  final double minWidth;
+  final double maxWidth;
 
   /// If `onPressed` is null then the button is painted gray to show that it's
   /// deactivated. If a `widget` is passed, the `_buttonText` is ignored and the
   /// `widget` is displayed instead.
-  const PEBRAButtonFlat(this._buttonText, {this.onPressed, this.widget}) : super();
+  const PEBRAButtonFlat(this._buttonText, {this.onPressed, this.widget, this.minWidth, this.maxWidth}) : super();
 
   @override
   Widget build(BuildContext context) {
     return ConstrainedBox(
       constraints: BoxConstraints(
-        maxWidth: 300,
-        minWidth: 150,
+        maxWidth: maxWidth ?? double.infinity,
+        minWidth: minWidth ?? 0.0,
         minHeight: 40,
       ),
       child: FlatButton(

--- a/lib/components/PEBRAButtonRaised.dart
+++ b/lib/components/PEBRAButtonRaised.dart
@@ -7,19 +7,21 @@ class PEBRAButtonRaised extends StatelessWidget {
   final onPressed;
   final Widget widget;
   final Color color;
+  final double minWidth;
+  final double maxWidth;
 
   /// If `onPressed` is null then the button is painted gray to show that it's
   /// deactivated. If a `widget` is passed, the `_buttonText` is ignored and the
   /// `widget` is displayed instead. Pass a [color] to override the default blue
   /// background color of the button.
-  const PEBRAButtonRaised(this._buttonText, {this.onPressed, this.widget, this.color}) : super();
+  const PEBRAButtonRaised(this._buttonText, {this.onPressed, this.widget, this.color, this.minWidth, this.maxWidth}) : super();
 
   @override
   Widget build(BuildContext context) {
     return ConstrainedBox(
       constraints: BoxConstraints(
-        maxWidth: 300,
-        minWidth: 150,
+        maxWidth: maxWidth ?? double.infinity,
+        minWidth: minWidth ?? 0.0,
         minHeight: 40,
       ),
       child: RaisedButton(

--- a/lib/components/PEBRAButtonRaised.dart
+++ b/lib/components/PEBRAButtonRaised.dart
@@ -6,11 +6,13 @@ class PEBRAButtonRaised extends StatelessWidget {
   final String _buttonText;
   final onPressed;
   final Widget widget;
+  final Color color;
 
   /// If `onPressed` is null then the button is painted gray to show that it's
   /// deactivated. If a `widget` is passed, the `_buttonText` is ignored and the
-  /// `widget` is displayed instead.
-  const PEBRAButtonRaised(this._buttonText, {this.onPressed, this.widget}) : super();
+  /// `widget` is displayed instead. Pass a [color] to override the default blue
+  /// background color of the button.
+  const PEBRAButtonRaised(this._buttonText, {this.onPressed, this.widget, this.color}) : super();
 
   @override
   Widget build(BuildContext context) {
@@ -22,7 +24,7 @@ class PEBRAButtonRaised extends StatelessWidget {
       ),
       child: RaisedButton(
         onPressed: this.onPressed,
-        color: RAISED_BUTTON,
+        color: color ?? RAISED_BUTTON,
         child: widget != null ? widget : Text(
           this._buttonText.toUpperCase(),
           style: TextStyle(

--- a/lib/utils/Utils.dart
+++ b/lib/utils/Utils.dart
@@ -71,7 +71,7 @@ Future<void> showFlushbar(String message, {String title, bool error=false, VoidC
     boxShadows: [BoxShadow(color: NOTIFICATION_SHADOW, blurRadius: 5.0, offset: Offset(0.0, 0.0), spreadRadius: 0.0)],
     borderRadius: 5,
     backgroundColor: error ? NOTIFICATION_ERROR : NOTIFICATION_NORMAL,
-    aroundPadding: EdgeInsets.symmetric(horizontal: padding),
+    margin: EdgeInsets.symmetric(horizontal: padding),
     duration: error ? null : Duration(seconds: 5),
   );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   cupertino_icons: ^0.1.2
   sqflite: ^1.1.0
   path: ^1.6.2
-  flushbar: ^1.7.1+1
+  flushbar: ^1.8.0
   url_launcher: ^5.0.2
   intl: ^0.15.7
   html: ^0.13.4+1


### PR DESCRIPTION
Closes #70.

- Show warning before logging out / transferring device.
- Removed default width of PEBRAButtons. They now adjust to the width of their child by default.
- Upgraded to flushbar 1.8.0 and fixed Travis CI build.

![logout](https://user-images.githubusercontent.com/24862276/61470166-e090ba00-a980-11e9-80ee-556fd9ac590e.png)