### PR TITLE
62 full birthday

### DIFF
--- a/lib/database/DatabaseProvider.dart
+++ b/lib/database/DatabaseProvider.dart
@@ -21,7 +21,7 @@ import 'package:pebrapp/utils/SwitchToolboxUtils.dart';
 class DatabaseProvider {
   // Increase the _DB_VERSION number if you made changes to the database schema.
   // An increase will call the [_onUpgrade] method.
-  static const int _DB_VERSION = 47;
+  static const int _DB_VERSION = 48;
   // Do not access the _database directly (it might be null), instead use the
   // _databaseInstance getter which will initialize the database if it is
   // uninitialized
@@ -66,7 +66,7 @@ class DatabaseProvider {
           ${Patient.colCreatedDate} TEXT NOT NULL,
           ${Patient.colEnrollmentDate} TEXT NOT NULL,
           ${Patient.colARTNumber} TEXT NOT NULL,
-          ${Patient.colYearOfBirth} TEXT NOT NULL,
+          ${Patient.colBirthday} TEXT NOT NULL,
           ${Patient.colIsEligible} BIT NOT NULL,
           ${Patient.colStickerNumber} TEXT,
           ${Patient.colIsVLBaselineAvailable} BIT,
@@ -559,6 +559,12 @@ class DatabaseProvider {
           done BIT NOT NULL
         );
         """);
+    }
+    if (oldVersion < 48 && _DB_VERSION >= 48) {
+      print('Upgrading to database version 48...');
+      print('UPGRADE NOT IMPLEMENTED, PATIENT DATA WILL BE RESET!');
+      await db.execute("DROP TABLE IF EXISTS Patient;");
+      await _onCreate(db, 48);
     }
   }
 

--- a/lib/database/models/Patient.dart
+++ b/lib/database/models/Patient.dart
@@ -21,7 +21,7 @@ class Patient implements IExcelExportable {
   static final colCreatedDate = 'created_date';
   static final colEnrollmentDate = 'enrollment_date';
   static final colARTNumber = 'art_number';
-  static final colYearOfBirth = 'year_of_birth';
+  static final colBirthday = 'birthday';
   static final colIsEligible = 'is_eligible';
   // nullables:
   static final colStickerNumber = 'sticker_number';
@@ -39,7 +39,7 @@ class Patient implements IExcelExportable {
   DateTime _createdDate;
   DateTime enrollmentDate;
   String artNumber;
-  int yearOfBirth;
+  DateTime birthday;
   bool isEligible;
   String stickerNumber;
   bool isVLBaselineAvailable;
@@ -67,7 +67,7 @@ class Patient implements IExcelExportable {
   // ------------
 
   Patient({this.enrollmentDate, this.artNumber, this.stickerNumber,
-    this.yearOfBirth, this.isEligible, this.isVLBaselineAvailable, this.gender,
+    this.birthday, this.isEligible, this.isVLBaselineAvailable, this.gender,
     this.sexualOrientation, this.village, this.phoneAvailability,
     this.phoneNumber, this.consentGiven, this.noConsentReason,
     this.noConsentReasonOther, this.isActivated});
@@ -76,7 +76,7 @@ class Patient implements IExcelExportable {
     this.createdDate = DateTime.parse(map[colCreatedDate]);
     this.enrollmentDate = DateTime.parse(map[colEnrollmentDate]);
     this.artNumber = map[colARTNumber];
-    this.yearOfBirth = int.parse(map[colYearOfBirth]);
+    this.birthday = DateTime.parse(map[colBirthday]);
     this.isEligible = map[colIsEligible] == 1;
     // nullables:
     this.stickerNumber = map[colStickerNumber];
@@ -108,7 +108,7 @@ class Patient implements IExcelExportable {
     map[colEnrollmentDate] = enrollmentDate.toIso8601String();
     map[colARTNumber] = artNumber;
     map[colStickerNumber] = stickerNumber;
-    map[colYearOfBirth] = yearOfBirth;
+    map[colBirthday] = birthday.toIso8601String();
     map[colIsEligible] = isEligible;
     // nullables:
     map[colIsVLBaselineAvailable] = isVLBaselineAvailable;
@@ -136,7 +136,7 @@ class Patient implements IExcelExportable {
     row[2] = 'DATE_ENROL';
     row[3] = 'TIME_ENROL';
     row[4] = 'IND_ID';
-    row[5] = 'BIRTH_YEAR';
+    row[5] = 'BIRTHDAY';
     row[6] = 'CONSENT';
     row[7] = 'CONSENT_NO';
     row[8] = 'CONSENT_OTHER';
@@ -163,7 +163,7 @@ class Patient implements IExcelExportable {
     row[2] = formatDateIso(enrollmentDate);
     row[3] = formatTimeIso(enrollmentDate);
     row[4] = artNumber;
-    row[5] = yearOfBirth;
+    row[5] = formatDateIso(birthday);
     row[6] = consentGiven;
     row[7] = noConsentReason?.code;
     row[8] = noConsentReasonOther;

--- a/lib/screens/NewPatientScreen.dart
+++ b/lib/screens/NewPatientScreen.dart
@@ -373,7 +373,6 @@ class _NewPatientFormState extends State<_NewPatientForm> {
                 ),
               ),
               onPressed: () async {
-                final now = DateTime.now();
                 DateTime date = await showDatePicker(
                   context: context,
                   initialDate: _newPatient.birthday ?? minBirthdayForEligibility,

--- a/lib/screens/NewPatientScreen.dart
+++ b/lib/screens/NewPatientScreen.dart
@@ -47,17 +47,12 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   final _questionsFlex = 1;
   final _answersFlex = 1;
 
-  static final currentYear = DateTime.now().year;
-
-  static final int birthYearOptionsStart = 1990;
-  static final int birthYearOptionsEnd = currentYear;
-  List<int> birthYearOptions = List<int>.generate(birthYearOptionsEnd - birthYearOptionsStart + 1, (i) => birthYearOptionsStart + i);
-
   static final int minAgeForEligibility = 15;
   static final int maxAgeForEligibility = 24;
-  static final int minYearForEligibility = currentYear - maxAgeForEligibility;
-  static final int maxYearForEligibility = currentYear - minAgeForEligibility;
-  bool get _eligible => _newPatient.yearOfBirth != null && _newPatient.yearOfBirth >= minYearForEligibility && _newPatient.yearOfBirth <= maxYearForEligibility;
+  static final DateTime now = DateTime.now();
+  static final DateTime minBirthdayForEligibility = DateTime(now.year - maxAgeForEligibility, now.month, now.day);
+  static final DateTime maxBirthdayForEligibility = DateTime(now.year - minAgeForEligibility, now.month, now.day);
+  bool get _eligible => _newPatient.birthday != null && !_newPatient.birthday.isBefore(minBirthdayForEligibility) && !_newPatient.birthday.isAfter(maxBirthdayForEligibility);
 
   Patient _newPatient = Patient(isActivated: true);
   ViralLoad _viralLoadBaseline = ViralLoad(source: ViralLoadSource.MANUAL_INPUT());
@@ -74,6 +69,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   // this field is used to display an error when the form is validated and if
   // the viral load baseline date is not selected
   bool _viralLoadBaselineDateValid = true;
+  bool _patientBirthdayValid = true;
 
   List<String> _artNumbersInDB;
   bool _isLoading = true;
@@ -260,7 +256,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
       child: Column(
         children: [
           _artNumberQuestion(),
-          _yearOfBirthQuestion(),
+          _birthdayQuestion(),
           _genderQuestion(),
           _sexualOrientationQuestion(),
           _villageQuestion(),
@@ -358,31 +354,52 @@ class _NewPatientFormState extends State<_NewPatientForm> {
     );
   }
 
-  Widget _yearOfBirthQuestion() {
-    return _makeQuestion('Year of Birth',
-        answer: DropdownButtonFormField<int>(
-          value: _newPatient.yearOfBirth,
-          onChanged: (int newValue) {
-            setState(() {
-              _newPatient.yearOfBirth = newValue;
-            });
-          },
-          validator: (value) {
-            if (value == null) { return 'Please select a year of birth.'; }
-          },
-          items: birthYearOptions.map<DropdownMenuItem<int>>((int value) {
-            String description = '$value';
-            return DropdownMenuItem<int>(
-              value: value,
-              child: Text(
-                description,
-                style: TextStyle(
-                  color: value <= maxYearForEligibility && value >= minYearForEligibility ? TEXT_ACTIVE : TEXT_INACTIVE,
+  Widget _birthdayQuestion() {
+    return _makeQuestion('Birthday',
+        answer: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            FlatButton(
+              padding: EdgeInsets.all(0.0),
+              child: SizedBox(
+                width: double.infinity,
+                child: Text(
+                  _newPatient.birthday == null ? '' : formatDateConsistent(_newPatient.birthday),
+                  textAlign: TextAlign.left,
+                  style: TextStyle(
+                    fontSize: 16.0,
+                    fontWeight: FontWeight.normal,
+                  ),
                 ),
               ),
-            );
-          }).toList(),
-        ),
+              onPressed: () async {
+                final now = DateTime.now();
+                DateTime date = await showDatePicker(
+                  context: context,
+                  initialDate: _newPatient.birthday ?? minBirthdayForEligibility,
+                  firstDate: minBirthdayForEligibility,
+                  lastDate: maxBirthdayForEligibility,
+                );
+                if (date != null) {
+                  setState(() {
+                    _newPatient.birthday = date;
+                  });
+                }
+              },
+            ),
+            Divider(color: CUSTOM_FORM_FIELD_UNDERLINE, height: 1.0,),
+            _patientBirthdayValid ? Container() : Padding(
+              padding: const EdgeInsets.only(top: 5.0),
+              child: Text(
+                'Please select a date',
+                style: TextStyle(
+                  color: CUSTOM_FORM_FIELD_ERROR_TEXT,
+                  fontSize: 12.0,
+                ),
+              ),
+            ),
+        ]
+      ),
     );
   }
 
@@ -604,7 +621,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
             child: SizedBox(
               width: double.infinity,
               child: Text(
-                _viralLoadBaseline.dateOfBloodDraw == null ? 'Select Date' : formatDateConsistent(_viralLoadBaseline.dateOfBloodDraw),
+                _viralLoadBaseline.dateOfBloodDraw == null ? '' : formatDateConsistent(_viralLoadBaseline.dateOfBloodDraw),
                 textAlign: TextAlign.left,
                 style: TextStyle(
                   fontSize: 16.0,
@@ -614,7 +631,12 @@ class _NewPatientFormState extends State<_NewPatientForm> {
             ),
             onPressed: () async {
               final now = DateTime.now();
-              DateTime date = await _showDatePicker(context, initialDate: _viralLoadBaseline.dateOfBloodDraw ?? DateTime(now.year, now.month, now.day));
+              DateTime date = await showDatePicker(
+                context: context,
+                initialDate: _viralLoadBaseline.dateOfBloodDraw ?? DateTime(now.year, now.month, now.day),
+                firstDate: DateTime(now.year - 1, now.month, now.day),
+                lastDate: DateTime(now.year, now.month, now.day),
+              );
               if (date != null) {
                 setState(() {
                   _viralLoadBaseline.dateOfBloodDraw = date;
@@ -708,7 +730,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   // ----------
 
   Widget _eligibilityDisclaimer() {
-    if (_newPatient.yearOfBirth == null || _eligible) {
+    if (_newPatient.birthday == null || _eligible) {
       return Container();
     }
     return
@@ -716,9 +738,9 @@ class _NewPatientFormState extends State<_NewPatientForm> {
         padding: EdgeInsets.only(top: 15.0),
         child:
         Text('This patient is not eligible for the study. Only patients born '
-            'between $minYearForEligibility and $maxYearForEligibility are '
-            'eligible. Please, save the patient anyway for study evaluation '
-            'reasons. The patient will not appear in the PEBRApp, however.',
+            'between ${formatDateConsistent(minBirthdayForEligibility)} and '
+            '${formatDateConsistent(maxBirthdayForEligibility)} are '
+            'eligible. The patient will not appear in the PEBRApp.',
           textAlign: TextAlign.left,
         ),
       );
@@ -740,13 +762,28 @@ class _NewPatientFormState extends State<_NewPatientForm> {
     return true;
   }
 
+  bool _validatePatientBirthday() {
+    // if the birthday is not specified show the error message under the
+    // birthday field and return false.
+    if (_newPatient.birthday == null) {
+      setState(() {
+        _patientBirthdayValid = false;
+      });
+      return false;
+    }
+    setState(() {
+      _patientBirthdayValid = true;
+    });
+    return true;
+  }
+
   /// Returns true if the form validation succeeds and the patient was saved
   /// successfully.
   Future<bool> _onSubmitForm() async {
     setState(() {
       _isLoading = true;
     });
-    if (_formKey.currentState.validate() & _validateViralLoadBaselineDate()) {
+    if (_formKey.currentState.validate() & _validatePatientBirthday() & _validateViralLoadBaselineDate()) {
 
       final DateTime now = DateTime.now();
 
@@ -893,16 +930,6 @@ class _NewPatientFormState extends State<_NewPatientForm> {
           ],
         );
       },
-    );
-  }
-
-  Future<DateTime> _showDatePicker(BuildContext context, {DateTime initialDate}) async {
-    DateTime now = DateTime.now();
-    return showDatePicker(
-      context: context,
-      initialDate: initialDate ?? now,
-      firstDate: DateTime(now.year - 1, now.month, now.day),
-      lastDate: DateTime.now(),
     );
   }
 

--- a/lib/screens/NewPatientScreen.dart
+++ b/lib/screens/NewPatientScreen.dart
@@ -50,7 +50,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   static final int minAgeForEligibility = 15;
   static final int maxAgeForEligibility = 24;
   static final DateTime now = DateTime.now();
-  static final DateTime minBirthdayForEligibility = DateTime(now.year - maxAgeForEligibility, now.month, now.day);
+  static final DateTime minBirthdayForEligibility = DateTime(now.year - maxAgeForEligibility - 1, now.month, now.day + 1);
   static final DateTime maxBirthdayForEligibility = DateTime(now.year - minAgeForEligibility, now.month, now.day);
   bool get _eligible => _newPatient.birthday != null && !_newPatient.birthday.isBefore(minBirthdayForEligibility) && !_newPatient.birthday.isAfter(maxBirthdayForEligibility);
 
@@ -364,7 +364,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
               child: SizedBox(
                 width: double.infinity,
                 child: Text(
-                  _newPatient.birthday == null ? '' : formatDateConsistent(_newPatient.birthday),
+                  _newPatient.birthday == null ? '' : '${formatDateConsistent(_newPatient.birthday)} (age ${calculateAge(_newPatient.birthday)})',
                   textAlign: TextAlign.left,
                   style: TextStyle(
                     fontSize: 16.0,

--- a/lib/screens/NewPatientScreen.dart
+++ b/lib/screens/NewPatientScreen.dart
@@ -106,6 +106,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
           _personalInformationCard(),
           _eligibilityDisclaimer(),
           _consentCard(),
+          _additionalInformationCard(),
           _viralLoadBaselineCard(),
           _notEligibleDisclaimer(),
         ],
@@ -259,11 +260,6 @@ class _NewPatientFormState extends State<_NewPatientForm> {
         children: [
           _artNumberQuestion(),
           _birthdayQuestion(),
-          _genderQuestion(),
-          _sexualOrientationQuestion(),
-          _villageQuestion(),
-          _phoneAvailabilityQuestion(),
-          _phoneNumberQuestion(),
         ],
       ),
     );
@@ -285,8 +281,25 @@ class _NewPatientFormState extends State<_NewPatientForm> {
     );
   }
 
+  Widget _additionalInformationCard() {
+    if (_notEligibleAfterBirthdaySpecified || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
+      return Container();
+    }
+    return _buildCard('Additional Information',
+      child: Column(
+        children: [
+          _genderQuestion(),
+          _sexualOrientationQuestion(),
+          _villageQuestion(),
+          _phoneAvailabilityQuestion(),
+          _phoneNumberQuestion(),
+        ],
+      ),
+    );
+  }
+
   Widget _viralLoadBaselineCard() {
-    if (!_eligible || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
+    if (_notEligibleAfterBirthdaySpecified || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
       return Container();
     }
     const double _spaceBetweenQuestions = 5.0;
@@ -405,9 +418,6 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   }
 
   Widget _genderQuestion() {
-    if (_notEligibleAfterBirthdaySpecified || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
-      return Container();
-    }
     return _makeQuestion(
       'Gender',
       answer: DropdownButtonFormField<Gender>(
@@ -431,9 +441,6 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   }
 
   Widget _sexualOrientationQuestion() {
-    if (_notEligibleAfterBirthdaySpecified || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
-      return Container();
-    }
     return _makeQuestion(
       'Sexual Orientation',
       answer: DropdownButtonFormField<SexualOrientation>(
@@ -457,9 +464,6 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   }
 
   Widget _villageQuestion() {
-    if (_notEligibleAfterBirthdaySpecified || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
-      return Container();
-    }
     return _makeQuestion(
       'Village',
       answer: TextFormField(
@@ -474,9 +478,6 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   }
 
   Widget _phoneAvailabilityQuestion() {
-    if (_notEligibleAfterBirthdaySpecified || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
-      return Container();
-    }
     return _makeQuestion('Do you have regular access to a phone (with Lesotho number) where you can receive confidential information?',
       answer: DropdownButtonFormField<PhoneAvailability>(
         value: _newPatient.phoneAvailability,
@@ -499,7 +500,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   }
 
   Widget _phoneNumberQuestion() {
-    if (_notEligibleAfterBirthdaySpecified || _newPatient.consentGiven == null || !_newPatient.consentGiven || _newPatient.phoneAvailability == null || _newPatient.phoneAvailability != PhoneAvailability.YES()) {
+    if (_newPatient.phoneAvailability == null || _newPatient.phoneAvailability != PhoneAvailability.YES()) {
       return Container();
     }
     return _makeQuestion('Phone Number',
@@ -731,7 +732,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   // ----------
 
   Widget _eligibilityDisclaimer() {
-    if (_newPatient.consentGiven ?? false || _newPatient.birthday != null) {
+    if (_newPatient.birthday != null) {
       return Container();
     }
     return

--- a/lib/screens/NewPatientScreen.dart
+++ b/lib/screens/NewPatientScreen.dart
@@ -53,6 +53,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   static final DateTime minBirthdayForEligibility = DateTime(now.year - maxAgeForEligibility - 1, now.month, now.day + 1);
   static final DateTime maxBirthdayForEligibility = DateTime(now.year - minAgeForEligibility, now.month, now.day);
   bool get _eligible => _newPatient.birthday != null && !_newPatient.birthday.isBefore(minBirthdayForEligibility) && !_newPatient.birthday.isAfter(maxBirthdayForEligibility);
+  bool get _notEligibleAfterBirthdaySpecified => _newPatient.birthday != null && !_eligible;
 
   Patient _newPatient = Patient(isActivated: true);
   ViralLoad _viralLoadBaseline = ViralLoad(source: ViralLoadSource.MANUAL_INPUT());
@@ -103,9 +104,10 @@ class _NewPatientFormState extends State<_NewPatientForm> {
       child: Column(
         children: [
           _personalInformationCard(),
+          _eligibilityDisclaimer(),
           _consentCard(),
           _viralLoadBaselineCard(),
-          _eligibilityDisclaimer(),
+          _notEligibleDisclaimer(),
         ],
       ),
     );
@@ -268,7 +270,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   }
 
   Widget _consentCard() {
-    if (!_eligible) {
+    if (_notEligibleAfterBirthdaySpecified) {
       return Container();
     }
     return _buildCard('Consent',
@@ -403,7 +405,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   }
 
   Widget _genderQuestion() {
-    if (!_eligible || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
+    if (_notEligibleAfterBirthdaySpecified || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
       return Container();
     }
     return _makeQuestion(
@@ -429,7 +431,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   }
 
   Widget _sexualOrientationQuestion() {
-    if (!_eligible || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
+    if (_notEligibleAfterBirthdaySpecified || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
       return Container();
     }
     return _makeQuestion(
@@ -455,7 +457,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   }
 
   Widget _villageQuestion() {
-    if (!_eligible || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
+    if (_notEligibleAfterBirthdaySpecified || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
       return Container();
     }
     return _makeQuestion(
@@ -472,7 +474,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   }
 
   Widget _phoneAvailabilityQuestion() {
-    if (!_eligible || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
+    if (_notEligibleAfterBirthdaySpecified || _newPatient.consentGiven == null || !_newPatient.consentGiven) {
       return Container();
     }
     return _makeQuestion('Do you have regular access to a phone (with Lesotho number) where you can receive confidential information?',
@@ -497,7 +499,7 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   }
 
   Widget _phoneNumberQuestion() {
-    if (!_eligible || _newPatient.consentGiven == null || !_newPatient.consentGiven || _newPatient.phoneAvailability == null || _newPatient.phoneAvailability != PhoneAvailability.YES()) {
+    if (_notEligibleAfterBirthdaySpecified || _newPatient.consentGiven == null || !_newPatient.consentGiven || _newPatient.phoneAvailability == null || _newPatient.phoneAvailability != PhoneAvailability.YES()) {
       return Container();
     }
     return _makeQuestion('Phone Number',
@@ -729,6 +731,20 @@ class _NewPatientFormState extends State<_NewPatientForm> {
   // ----------
 
   Widget _eligibilityDisclaimer() {
+    if (_newPatient.consentGiven ?? false || _newPatient.birthday != null) {
+      return Container();
+    }
+    return
+      Padding(
+        padding: EdgeInsets.only(top: 15.0),
+        child:
+        Text('Only patients between ages $minAgeForEligibility and $maxAgeForEligibility are eligible.',
+          textAlign: TextAlign.left,
+        ),
+      );
+  }
+
+  Widget _notEligibleDisclaimer() {
     if (_newPatient.birthday == null || _eligible) {
       return Container();
     }

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -253,7 +253,7 @@ class _PatientScreenState extends State<PatientScreen> {
           _buildRow('Enrollment Date', formatDateConsistent(_patient.enrollmentDate)),
           _buildRow('ART Number', _patient.artNumber),
           _buildRow('Sticker Number', _patient.stickerNumber),
-          _buildRow('Year of Birth', _patient.yearOfBirth.toString()),
+          _buildRow('Year of Birth', _patient.birthday.toString()),
           _buildRow('Gender', _patient.gender.description),
           _buildRow('Sexual Orientation', _patient.sexualOrientation.description),
           _buildRow('Village', _patient.village),

--- a/lib/screens/PatientScreen.dart
+++ b/lib/screens/PatientScreen.dart
@@ -253,7 +253,7 @@ class _PatientScreenState extends State<PatientScreen> {
           _buildRow('Enrollment Date', formatDateConsistent(_patient.enrollmentDate)),
           _buildRow('ART Number', _patient.artNumber),
           _buildRow('Sticker Number', _patient.stickerNumber),
-          _buildRow('Year of Birth', _patient.birthday.toString()),
+          _buildRow('Birthday', '${formatDateConsistent(_patient.birthday)} (age ${calculateAge(_patient.birthday)})'),
           _buildRow('Gender', _patient.gender.description),
           _buildRow('Sexual Orientation', _patient.sexualOrientation.description),
           _buildRow('Village', _patient.village),

--- a/lib/utils/Utils.dart
+++ b/lib/utils/Utils.dart
@@ -104,6 +104,23 @@ int differenceInDays(DateTime date1, DateTime date2) {
   return date2.difference(date1).inDays;
 }
 
+/// Calculates age of someone since his/her [birthday].
+///
+/// Returns today's age in years.
+int calculateAge(DateTime birthday) {
+  final DateTime birthdayUtc = birthday.toLocal();
+  final DateTime now = DateTime.now().toLocal();
+  int years = now.year - birthdayUtc.year;
+  if (birthdayUtc.month > now.month) {
+    // birthday is yet to come this year
+    years--;
+  } else if (birthdayUtc.month == now.month && birthdayUtc.day > now.day) {
+    // birthday is yet to come this month
+    years--;
+  }
+  return years;
+}
+
 /// Turns date into the format dd.MM.yyyy.
 String formatDateConsistent(DateTime date) {
   return DateFormat("dd.MM.yyyy").format(date.toLocal());


### PR DESCRIPTION
Closes #62.
Closes #68.

- Ask for birthday instead of just birth year when creating a new patient.
- Only birthdays in the eligible age range (15-24) can be selected in the date picker.
- Display patient's age on patient screen.
- Display patient's age on new patient screen after birthday has been specified.
- Show consent card immediately instead of waiting for the user to specify the birthday.
- Moved gender, sexual orientation, village, and phone number questions to their own card.