### PR TITLE
88 change flagging

### DIFF
--- a/lib/screens/ARTRefillScreen.dart
+++ b/lib/screens/ARTRefillScreen.dart
@@ -93,7 +93,7 @@ class ARTRefillScreen extends StatelessWidget {
 
   Future<DateTime> _showDatePickerWithTitle(BuildContext context, String title) async {
     final DateTime now = DateTime.now();
-    return showDatePicker(context: context, initialDate: now, firstDate: now.subtract(Duration(days: 1)), lastDate: DateTime(2050), builder: (BuildContext context, Widget widget) {
+    return showDatePicker(context: context, initialDate: _patient.latestARTRefill?.nextRefillDate ?? now, firstDate: now.subtract(Duration(days: 1)), lastDate: DateTime(2050), builder: (BuildContext context, Widget widget) {
       return PopupScreen(
         backgroundColor: Colors.transparent,
         actions: [],

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -144,8 +144,6 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
   /// Sorts patients in the following way:
   ///
   /// - activated patients before deactivated patients
-  /// - patients with more required actions before patients with less required
-  ///   actions
   /// - patients with missing ART refill or preference assessment before
   ///   patients with ART refill or preference assessment
   /// - patients with next action (ART refill / preference assessment) closer in
@@ -156,22 +154,16 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
     patients.sort((Patient a, Patient b) {
       if (a.isActivated && !b.isActivated) { return -1; }
       if (!a.isActivated && b.isActivated) { return 1; } // do we need this rule or is it implied by the previous rule?
-      final int actionsRequiredForA = a.calculateDueRequiredActions().length;
-      final int actionsRequiredForB = b.calculateDueRequiredActions().length;
-      if (actionsRequiredForA > actionsRequiredForB) { return -1; }
-      if (actionsRequiredForA < actionsRequiredForB) { return 1; } // do we need this rule or is it implied by the previous rule?
-      if (actionsRequiredForA == actionsRequiredForB) {
-        final DateTime dateOfNextActionA = _getDateOfNextAction(a);
-        final DateTime dateOfNextActionB = _getDateOfNextAction(b);
-        if (dateOfNextActionA == null && dateOfNextActionB != null) {
-          return -1;
-        }
-        if (dateOfNextActionA != null && dateOfNextActionB == null) {
-          return 1;
-        }
-        if (dateOfNextActionA != null && dateOfNextActionB != null && !dateOfNextActionA.isAtSameMomentAs(dateOfNextActionB)) {
-          return dateOfNextActionA.isBefore(dateOfNextActionB) ? -1 : 1;
-        }
+      final DateTime dateOfNextActionA = _getDateOfNextAction(a);
+      final DateTime dateOfNextActionB = _getDateOfNextAction(b);
+      if (dateOfNextActionA == null && dateOfNextActionB != null) {
+        return -1;
+      }
+      if (dateOfNextActionA != null && dateOfNextActionB == null) {
+        return 1;
+      }
+      if (dateOfNextActionA != null && dateOfNextActionB != null && !dateOfNextActionA.isAtSameMomentAs(dateOfNextActionB)) {
+        return dateOfNextActionA.isBefore(dateOfNextActionB) ? -1 : 1;
       }
       return a.createdDate.isBefore(b.createdDate) ? 1 : -1;
     });
@@ -914,10 +906,6 @@ class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver, Ti
   Color _calculateCardColor(Patient patient) {
     if (!patient.isActivated) {
       return Colors.transparent;
-    }
-
-    if (patient.calculateDueRequiredActions().length > 0) {
-      return URGENCY_HIGH;
     }
 
     final DateTime dateOfNextAction = _getDateOfNextAction(patient);


### PR DESCRIPTION
Closes #88.

- Ignore the number of required actions for sorting and coloring of participant cards on main screen.
- Initialize the date picker on the ART refill screen to the date of the next refill.